### PR TITLE
Hide loading mask on a pre-save validation error

### DIFF
--- a/src/components/steps/save/SaveStep.tsx
+++ b/src/components/steps/save/SaveStep.tsx
@@ -62,6 +62,7 @@ const SaveStep: React.FC<StepProps> = ({ project, onCancel, action }) => {
         const validation = await project.validate();
         const error = _(validation).values().flatten().join("\n");
         if (error) {
+            loading.hide();
             snackbar.error(error);
             return;
         }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/3x168kg