### PR TITLE
[fix] Sort by last updated data on projects table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "data-management-app",
     "description": "DHIS2 Data Management App",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/pages/projects-list/ProjectsListConfig.tsx
+++ b/src/pages/projects-list/ProjectsListConfig.tsx
@@ -78,23 +78,23 @@ export function getComponentConfig(
         {
             ...columnDate("lastUpdatedData", "datetime"),
             text: i18n.t("Last Updated (data)"),
+            getValue: project => project.lastUpdatedData || "-",
             sortable: true,
         },
     ];
 
-    const details = [
+    const details: TableColumn<ProjectForList>[] = [
         ...columns,
         { name: "displayDescription" as const, text: i18n.t("Description") },
         {
             name: "user" as const,
             text: i18n.t("Created By"),
-            getValue: (project: ProjectForList) => `${project.user.displayName}`,
+            getValue: project => `${project.user.displayName}`,
         },
         {
             name: "lastUpdatedBy" as const,
             text: i18n.t("Last Updated By"),
-            getValue: (project: ProjectForList) =>
-                `${project.lastUpdatedBy ? project.lastUpdatedBy.name : "-"}`,
+            getValue: project => `${project.lastUpdatedBy ? project.lastUpdatedBy.name : "-"}`,
         },
         {
             name: "sharing" as const,

--- a/src/pages/projects-list/ProjectsListConfig.tsx
+++ b/src/pages/projects-list/ProjectsListConfig.tsx
@@ -78,7 +78,7 @@ export function getComponentConfig(
         {
             ...columnDate("lastUpdatedData", "datetime"),
             text: i18n.t("Last Updated (data)"),
-            getValue: project => project.lastUpdatedData || "-",
+            getValue: project => formatDateLong(project.lastUpdatedData) || "-",
             sortable: true,
         },
     ];


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/35z1hjf

### :memo: Implementation

- When the field to sort by is lastUpdatedData, get dataSets with update info and map to the orgUnits.