### PR TITLE
Make projects country filter dependent of onlyActive filter

### DIFF
--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -486,6 +486,16 @@ class Project {
         return projectsList.get(filters, sorting, pagination);
     }
 
+    static async getCountriesOnlyActive(api: D2Api, config: Config) {
+        const projectsList = new ProjectList(api, config);
+        const { countries } = await projectsList.get(
+            { onlyActive: true },
+            { field: "id", order: "asc" },
+            { page: 1, pageSize: 1 }
+        );
+        return countries;
+    }
+
     setSectors(sectors: Sector[]): Project {
         return this.setObj({
             sectors: sectors,

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -496,6 +496,16 @@ class Project {
         return countries;
     }
 
+    static async getCountries(api: D2Api, config: Config) {
+        const projectsList = new ProjectList(api, config);
+        const { countries } = await projectsList.get(
+            {},
+            { field: "id", order: "asc" },
+            { page: 1, pageSize: 1 }
+        );
+        return countries;
+    }
+
     setSectors(sectors: Sector[]): Project {
         return this.setObj({
             sectors: sectors,

--- a/src/models/ProjectsList.ts
+++ b/src/models/ProjectsList.ts
@@ -54,6 +54,11 @@ export interface ProjectForList extends BaseProject {
     lastUpdatedData: string;
 }
 
+export interface Country {
+    id: string;
+    displayName: string;
+}
+
 export default class ProjectsList {
     currentUser: User;
 
@@ -65,7 +70,7 @@ export default class ProjectsList {
         filters: FiltersForList,
         sorting: TableSorting<ProjectForList>,
         pagination: Pagination
-    ): Promise<{ objects: ProjectForList[]; pager: Pager }> {
+    ): Promise<{ objects: ProjectForList[]; countries: Country[]; pager: Pager }> {
         const { api, config } = this;
         const order = `${sorting.field}:i${sorting.order}`;
         const orgUnitIds = await this.getBaseOrgUnitIds(api, config, filters, order);
@@ -153,7 +158,16 @@ export default class ProjectsList {
             return project;
         });
 
-        return paginate(_.compact(projectsWithSectors), pagination);
+        const { pager, objects } = paginate(_.compact(projectsWithSectors), pagination);
+
+        const countries: Country[] = _(projects)
+            .map(project => project.parent)
+            .compact()
+            .uniqBy(country => country.id)
+            .sortBy(country => country.displayName)
+            .value();
+
+        return { pager, objects, countries: countries };
     }
 
     private async getDataSetsWithLastUpdatedData() {

--- a/src/pages/projects-list/ProjectsList.tsx
+++ b/src/pages/projects-list/ProjectsList.tsx
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { TableSorting } from "@eyeseetea/d2-ui-components";
 import React, { useCallback, useState } from "react";
 import styled from "styled-components";
@@ -137,8 +138,21 @@ function useFilterOptions() {
 
     React.useEffect(() => {
         async function run() {
-            const countriesOnlyActive = await Project.getCountriesOnlyActive(api, config);
-            setFilterOptions(prev => ({ ...prev, countriesOnlyActive }));
+            const countriesFromProjects = await Project.getCountries(api, config);
+
+            const countriesAll = _.intersectionBy(
+                countriesFromProjects,
+                currentUser.getCountries(),
+                country => country.id
+            );
+
+            const newFilterOptions: FilterOptions = {
+                countriesAll: countriesAll,
+                sectors: config.sectors,
+                countriesOnlyActive: await Project.getCountriesOnlyActive(api, config),
+            };
+
+            setFilterOptions(newFilterOptions);
         }
         run();
     }, [api, currentUser, config]);

--- a/src/pages/projects-list/ProjectsList.tsx
+++ b/src/pages/projects-list/ProjectsList.tsx
@@ -18,7 +18,7 @@ import { FiltersForList, ProjectForList } from "../../models/ProjectsList";
 import { useGoTo } from "../../router";
 import { Id } from "../../types/d2-api";
 import { getComponentConfig, UrlState } from "./ProjectsListConfig";
-import ProjectsListFilters from "./ProjectsListFilters";
+import ProjectsListFilters, { FilterOptions } from "./ProjectsListFilters";
 import { useUrlParams } from "../../utils/use-url-params";
 import { useQueryStringParams } from "./ProjectsListParams";
 
@@ -63,9 +63,7 @@ const ProjectsList: React.FC = () => {
 
     const tableProps = useObjectsTable(componentConfig, getRows, params, updateState);
 
-    const filterOptions = React.useMemo(() => {
-        return { countries: currentUser.getCountries(), sectors: config.sectors };
-    }, [currentUser, config]);
+    const filterOptions = useFilterOptions();
 
     const closeDeleteDialog = useCallback(() => {
         setProjectIdsToDelete(undefined);
@@ -127,5 +125,25 @@ const ObjectsListStyled = styled(ObjectsList)`
         max-width: 250px;
     }
 `;
+
+function useFilterOptions() {
+    const { api, currentUser, config } = useAppContext();
+
+    const [filterOptions, setFilterOptions] = React.useState<FilterOptions>(() => ({
+        countriesAll: currentUser.getCountries(),
+        countriesOnlyActive: [],
+        sectors: config.sectors,
+    }));
+
+    React.useEffect(() => {
+        async function run() {
+            const countriesOnlyActive = await Project.getCountriesOnlyActive(api, config);
+            setFilterOptions(prev => ({ ...prev, countriesOnlyActive }));
+        }
+        run();
+    }, [api, currentUser, config]);
+
+    return filterOptions;
+}
 
 export default React.memo(ProjectsList);

--- a/src/pages/projects-list/ProjectsListFilters.tsx
+++ b/src/pages/projects-list/ProjectsListFilters.tsx
@@ -23,7 +23,8 @@ export interface Option {
 }
 
 export interface FilterOptions {
-    countries: Option[];
+    countriesAll: Option[];
+    countriesOnlyActive: Option[];
     sectors: Option[];
 }
 
@@ -34,7 +35,9 @@ type OnChange = NonNullable<CheckboxProps["onChange"]>;
 const ProjectsListFilters: React.FC<ProjectsListFiltersProps> = props => {
     const { filter, filterOptions, onChange } = props;
     const classes = useStyles();
-    const countryItems = useMemoOptions(filterOptions.countries);
+    const countryItems = useMemoOptions(
+        filter.onlyActive ? filterOptions.countriesOnlyActive : filterOptions.countriesAll
+    );
     const sectorItems = useMemoOptions(filterOptions.sectors);
 
     const notifyCountriesChange = React.useCallback(


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865cqdh5p

### :memo: Implementation

- On app init, get all countries and countries only for active projects, and use to fill the dropdown 

### :fire: Notes for the reviewer

docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-pro