### PR TITLE
[feature] Set short name for org unit groups + fix-all script

### DIFF
--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -891,9 +891,12 @@ async function getOrgUnitGroupsMetadata(
         })
         .getData();
 
+    const name = `Award Number ${project.awardNumber}`;
+
     const awardNumberOrgUnitGroupBase: OrgUnitGroup = {
         id: getUid("awardNumber", project.awardNumber),
-        name: `Award Number ${project.awardNumber}`,
+        name: name,
+        shortName: name,
         code: config.base.organisationUnitGroups.awardNumberPrefix + project.awardNumber,
         organisationUnits: [],
         attributeValues: [],
@@ -916,6 +919,7 @@ async function getOrgUnitGroupsMetadata(
         .concat(newOrgUnitGroups as OrgUnitGroup[])
         .concat([awardNumberOrgUnitGroupBase])
         .uniqBy(oug => oug.id)
+        .map(setDefaultShortName)
         .map(oug =>
             oug.id === awardNumberOrgUnitGroupBase.id && dashboards.awardNumber // Set dashboard ID to awardNumber group
                 ? addAttributeValueToObj(oug, {
@@ -1120,3 +1124,9 @@ const dataValuesDatesGetAll: Required<Pick<DataValueSetsGetRequest, "startDate" 
     startDate: "1970",
     endDate: (new Date().getFullYear() + 10).toString(),
 };
+
+type ObjWithShortName = Partial<{ name: string; shortName: string }>;
+
+function setDefaultShortName<T extends ObjWithShortName>(obj: T): T {
+    return { ...obj, shortName: obj.shortName || obj.name };
+}

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -46,6 +46,7 @@
             "created": "2020-01-02T12:32:30.449",
             "lastUpdated": "2020-01-02T14:28:43.045",
             "name": "Abaco",
+            "shortName": "Abaco",
             "id": "GG0k0oNhgS7",
             "publicAccess": "rw------",
             "lastUpdatedBy": {
@@ -69,6 +70,7 @@
             "created": "2020-01-02T11:55:10.244",
             "lastUpdated": "2020-01-02T14:28:43.050",
             "name": "Agridius Foundation",
+            "shortName": "Agridius Foundation",
             "id": "em8NIwi0KvM",
             "publicAccess": "rw------",
             "lastUpdatedBy": {
@@ -106,6 +108,7 @@
         {
             "id": "WIEp6vpQw6n",
             "name": "Award Number 12345",
+            "shortName": "Award Number 12345",
             "code": "AWARD_NUMBER_12345",
             "organisationUnits": [
                 {

--- a/src/scripts/fix-dimensionable-entities.sh
+++ b/src/scripts/fix-dimensionable-entities.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Set shortName for all dimensionable entities (children of entities with flag 'dataDimensions'):
+#
+#  - category -> categoryOptions
+#  - categoryOptionGroupSet -> categoryOptionGroups
+#  - dataElementGroupSet -> dataElementGroups
+#  - optionGroupSet -> optionGroups
+#  - organisationUnitGroupSet -> organisationUnitGroups
+
+# Usage:
+#
+#   $ export IP_ADMIN_AUTH=admin:PASSWORD
+#   $ src/scripts/fix-dimensionable-entities.sh http://localhost:8080 "admin:PASSWORD"
+
+debug() {
+    echo "$@" >&2
+}
+
+curl2() {
+    debug "curl" "$@"
+    curl -g -sS -u "$IP_ADMIN_AUTH" "$@"
+}
+
+curl_post() {
+    curl2 -H "Content-Type: application/json" -X POST "$@"
+}
+
+post_metadata() {
+    local url=$1 file=$2
+    curl_post "$url/api/metadata?dryRun=${DRY_RUN:-false}" -d@"$file" | jq |
+        tee metadata-res.json | jq -c '[.status, .stats]' >&2
+}
+
+set_default_short_name() {
+    local url=$1 model=$2
+    local count
+    debug "Set default shortName: model=$model"
+
+    curl2 "$url/api/$model.json?paging=false&fields=:owner" | jq-clean >"metadata-$model.json"
+
+    cat "metadata-$model.json" |
+        jq --arg model "$model" '
+            .[$model] as $records |
+              $records |
+              map(select(.code != "default")) |
+              map(. * {shortName: (.shortName // .name)}) |
+              (. - $records) |
+              {($model): .}
+        ' >"metadata2-$model.json"
+
+    count=$(cat "metadata2-$model.json" | jq --arg model "$model" '.[$model] | length')
+    debug "$model:POST-count: $count"
+
+    if test "$count" -gt 0; then
+        post_metadata "$url" ""metadata2-$model.json""
+    fi
+}
+
+models=(
+    categoryOptions
+    categoryOptionGroups
+    dataElementGroups
+    optionGroups
+    organisationUnitGroups
+)
+
+main() {
+    set -e -u -o pipefail
+    local url=$1 password=$2
+    export IP_ADMIN_AUTH=${password}
+
+    for model in "${models[@]}"; do
+        set_default_short_name "$url" "$model"
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865cqe4pj

### :memo: Implementation

- The app posts orgUnitGroups when the project is saved/created. At this point, I've added the property shortName for the award number orgUnitGroup. 
- Additionally, as we have to post orgUnitGroups for locations and funders, I've added a default `obj.shortName = obj.shortName || obj.name` so these entities will be fixed on the fly.
- Note that the are many (almost all of them) dimensions which are lacking the shortName for the entries (see the visualization app and click on the dimensions). For completeness, I've grepped in the schema all the dimensionable entities, that's the result:
```
- category -> categoryOptions
- categoryOptionGroupSet -> categoryOptionGroups
- dataElementGroupSet -> dataElementGroups
- optionGroupSet -> optionGroups
- organisationUnitGroupSet -> organisationUnitGroups
```
- Created script that fixed all these entities: `src/scripts/fix-dimensionable-entities.sh http://localhost:8080 $IP_ADMIN_AUTH`

### :fire: Notes for the reviewer

docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-pro
