### PR TITLE
Change MER validations on project create/edit wizard

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-10-24T06:53:19.502Z\n"
-"PO-Revision-Date: 2022-10-24T06:53:19.502Z\n"
+"POT-Creation-Date: 2023-07-21T10:15:22.368Z\n"
+"PO-Revision-Date: 2023-07-21T10:15:22.368Z\n"
 
 msgid "Name"
 msgstr ""
@@ -668,7 +668,10 @@ msgstr ""
 msgid "The following sectors have no indicators selected"
 msgstr ""
 
-msgid "Select at least one indicator"
+msgid "Select at least a total of {{min}} indicators"
+msgstr ""
+
+msgid "Select at most a total of {{max}} indicators"
 msgstr ""
 
 msgid ""

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -22,6 +22,7 @@ import User from "../../models/user";
 import { createGenerateClassName, LinearProgress, StylesProvider } from "@material-ui/core";
 import Migrations from "../migrations/Migrations";
 import { useMigrations } from "../migrations/hooks";
+import { isTest } from "../../utils/tests";
 
 const appKey = "data-management-app";
 
@@ -100,8 +101,16 @@ const App: React.FC<AppProps> = props => {
             }).then(res => res.json());
             const config = await getConfig(api);
             const currentUser = new User(config);
-            const isTest = process.env.REACT_APP_CYPRESS === "true";
-            const appContext = { d2, api, config, currentUser, isDev, isTest, appConfig, dhis2Url };
+            const appContext = {
+                d2,
+                api,
+                config,
+                currentUser,
+                isDev,
+                isTest: isTest(),
+                appConfig,
+                dhis2Url,
+            };
             setAppContext(appContext);
 
             Object.assign(window, { dm: appContext });

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -22,7 +22,7 @@ import User from "../../models/user";
 import { createGenerateClassName, LinearProgress, StylesProvider } from "@material-ui/core";
 import Migrations from "../migrations/Migrations";
 import { useMigrations } from "../migrations/hooks";
-import { isTest } from "../../utils/tests";
+import { isTest } from "../../utils/testing";
 
 const appKey = "data-management-app";
 

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -26,6 +26,7 @@ import ProjectSharing from "./ProjectSharing";
 import { Disaggregation, SetCovid19WithRelationsOptions } from "./Disaggregation";
 import { Sharing } from "./Sharing";
 import { getIds } from "../utils/dhis2";
+import { isTest } from "../utils/tests";
 
 /*
 Project model.
@@ -273,9 +274,10 @@ class Project {
 
     validateMER(): ValidationError {
         return _.concat(
-            this.dataElementsMER.validateAtLeastOneSelected(this.sectors),
-            this.dataElementsMER.validateMaxSelectedBySector(this.sectors, 3),
-            this.dataElementsMER.validateMaxSectorsWithSelections(this.sectors, 3)
+            this.dataElementsMER.validateTotalSelectedCount(this.sectors, {
+                min: isTest() ? 1 : 3,
+                max: 5,
+            })
         );
     }
 

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -273,9 +273,11 @@ class Project {
     };
 
     validateMER(): ValidationError {
+        const selected = this.dataElementsSelection.getAllSelected();
+
         return _.concat(
             this.dataElementsMER.validateTotalSelectedCount(this.sectors, {
-                min: isTest() ? 1 : 3,
+                min: isTest() ? 1 : Math.min(selected.length, 3),
                 max: 5,
             })
         );

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -26,7 +26,7 @@ import ProjectSharing from "./ProjectSharing";
 import { Disaggregation, SetCovid19WithRelationsOptions } from "./Disaggregation";
 import { Sharing } from "./Sharing";
 import { getIds } from "../utils/dhis2";
-import { isTest } from "../utils/tests";
+import { isTest } from "../utils/testing";
 
 /*
 Project model.

--- a/src/models/dataElementsSet.ts
+++ b/src/models/dataElementsSet.ts
@@ -122,9 +122,19 @@ export default class DataElementsSet {
         return this.get({ onlySelected: true }).filter(de => sectorIds.has(de.sector.id));
     }
 
-    validateAtLeastOneSelected(projectSectors: Sector[]): ValidationError {
+    validateTotalSelectedCount(
+        projectSectors: Sector[],
+        counts: { min: number; max: number }
+    ): ValidationError {
         const selected = this.getSelectedForSectors(projectSectors);
-        return _.isEmpty(selected) ? [i18n.t("Select at least one indicator")] : [];
+
+        if (selected.length < counts.min) {
+            return [i18n.t("Select at least a total of {{min}} indicators", counts)];
+        } else if (selected.length > counts.max) {
+            return [i18n.t("Select at most a total of {{max}} indicators", counts)];
+        } else {
+            return [];
+        }
     }
 
     validateMaxSelectedBySector(projectSectors: Sector[], maxCount: number): ValidationError {

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -1,0 +1,3 @@
+export function isTest(): boolean {
+    return process.env.REACT_APP_CYPRESS === "true" || process.env.JEST_WORKER_ID !== undefined;
+}

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -54,3 +54,7 @@ function writeJsonFile(data: any, prefix: string): string {
     fs.writeFileSync(file.fd, json);
     return filePath;
 }
+
+export function isTest(): boolean {
+    return process.env.REACT_APP_CYPRESS === "true" || process.env.JEST_WORKER_ID !== undefined;
+}

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -54,7 +54,3 @@ function writeJsonFile(data: any, prefix: string): string {
     fs.writeFileSync(file.fd, json);
     return filePath;
 }
-
-export function isTest(): boolean {
-    return process.env.REACT_APP_CYPRESS === "true" || process.env.JEST_WORKER_ID !== undefined;
-}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865cqyngg

### :memo: Implementation

The previous MER validations were:

```
this.dataElementsMER.validateAtLeastOneSelected(this.sectors),
this.dataElementsMER.validateMaxSelectedBySector(this.sectors, 3),
this.dataElementsMER.validateMaxSectorsWithSelections(this.sectors, 3)
```

The new validations (the min/max refer to the total count, right?):

```
this.dataElementsMER.validateTotalSelectedCount(this.sectors, { minCount: 3, maxCount: 5 })
```

- To discuss: what happens if for example we only have a total of 2 indicators in the project? The condition >= 3 will never be valid.

### :fire: Notes for the reviewer

d2-docker start docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-pro -p 8036