### PR TITLE
[fix] Use onlyActive to builder unique countries item list

### DIFF
--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -496,10 +496,10 @@ class Project {
         return countries;
     }
 
-    static async getCountries(api: D2Api, config: Config) {
+    static async getCountries(api: D2Api, config: Config, filters: FiltersForList) {
         const projectsList = new ProjectList(api, config);
         const { countries } = await projectsList.get(
-            {},
+            filters,
             { field: "id", order: "asc" },
             { page: 1, pageSize: 1 }
         );

--- a/src/pages/projects-list/ProjectsList.tsx
+++ b/src/pages/projects-list/ProjectsList.tsx
@@ -64,7 +64,7 @@ const ProjectsList: React.FC = () => {
 
     const tableProps = useObjectsTable(componentConfig, getRows, params, updateState);
 
-    const filterOptions = useFilterOptions();
+    const filterOptions = useFilterOptions(params);
 
     const closeDeleteDialog = useCallback(() => {
         setProjectIdsToDelete(undefined);
@@ -127,35 +127,35 @@ const ObjectsListStyled = styled(ObjectsList)`
     }
 `;
 
-function useFilterOptions() {
+function useFilterOptions(options: { onlyActive: boolean }) {
     const { api, currentUser, config } = useAppContext();
+    const { onlyActive } = options;
 
     const [filterOptions, setFilterOptions] = React.useState<FilterOptions>(() => ({
-        countriesAll: currentUser.getCountries(),
+        countries: currentUser.getCountries(),
         countriesOnlyActive: [],
         sectors: config.sectors,
     }));
 
     React.useEffect(() => {
         async function run() {
-            const countriesFromProjects = await Project.getCountries(api, config);
+            const countriesFromProjects = await Project.getCountries(api, config, { onlyActive });
 
-            const countriesAll = _.intersectionBy(
+            const countriesFromProjectVisibleByUser = _.intersectionBy(
                 countriesFromProjects,
                 currentUser.getCountries(),
                 country => country.id
             );
 
             const newFilterOptions: FilterOptions = {
-                countriesAll: countriesAll,
+                countries: countriesFromProjectVisibleByUser,
                 sectors: config.sectors,
-                countriesOnlyActive: await Project.getCountriesOnlyActive(api, config),
             };
 
             setFilterOptions(newFilterOptions);
         }
         run();
-    }, [api, currentUser, config]);
+    }, [api, currentUser, config, onlyActive]);
 
     return filterOptions;
 }

--- a/src/pages/projects-list/ProjectsListFilters.tsx
+++ b/src/pages/projects-list/ProjectsListFilters.tsx
@@ -23,8 +23,7 @@ export interface Option {
 }
 
 export interface FilterOptions {
-    countriesAll: Option[];
-    countriesOnlyActive: Option[];
+    countries: Option[];
     sectors: Option[];
 }
 
@@ -35,9 +34,7 @@ type OnChange = NonNullable<CheckboxProps["onChange"]>;
 const ProjectsListFilters: React.FC<ProjectsListFiltersProps> = props => {
     const { filter, filterOptions, onChange } = props;
     const classes = useStyles();
-    const countryItems = useMemoOptions(
-        filter.onlyActive ? filterOptions.countriesOnlyActive : filterOptions.countriesAll
-    );
+    const countryItems = useMemoOptions(filterOptions.countries);
     const sectorItems = useMemoOptions(filterOptions.sectors);
 
     const notifyCountriesChange = React.useCallback(


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865bfr3vv

### :memo: Implementation

- We had an old logic for the countries selector, remove it and use only the new one: get countries from listing (filter: onlyActive) and intersect with the user countries.