### PR TITLE
Update datavalues to other periods

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-11-17T15:59:58.244Z\n"
-"PO-Revision-Date: 2023-11-17T15:59:58.244Z\n"
+"POT-Creation-Date: 2023-11-20T13:28:37.376Z\n"
+"PO-Revision-Date: 2023-11-20T13:28:37.376Z\n"
 
 msgid "Name"
 msgstr ""
@@ -51,13 +51,6 @@ msgstr ""
 msgid "Data Entry"
 msgstr ""
 
-msgid ""
-"This action is going to unaproved all the periods. You will have to approve "
-"the data again on the Data Approval section. Are you sure you want to apply "
-"the current values to all months? The existing data in other months will be "
-"overwritten."
-msgstr ""
-
 msgid "An email has been sent to the data reviewers"
 msgstr ""
 
@@ -82,6 +75,13 @@ msgid ""
 msgstr ""
 
 msgid "Apply to all months"
+msgstr ""
+
+msgid ""
+"This action is going to unapprove all the periods. You will have to approve "
+"the data again on the Data Approval section. Are you sure you want to apply "
+"the current values to all months? The existing data in other months will be "
+"overwritten."
 msgstr ""
 
 msgid "Applying values to all months..."

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-09-13T11:54:43.059Z\n"
-"PO-Revision-Date: 2023-09-13T11:54:43.059Z\n"
+"POT-Creation-Date: 2023-11-17T15:59:58.244Z\n"
+"PO-Revision-Date: 2023-11-17T15:59:58.244Z\n"
 
 msgid "Name"
 msgstr ""
@@ -51,6 +51,13 @@ msgstr ""
 msgid "Data Entry"
 msgstr ""
 
+msgid ""
+"This action is going to unaproved all the periods. You will have to approve "
+"the data again on the Data Approval section. Are you sure you want to apply "
+"the current values to all months? The existing data in other months will be "
+"overwritten."
+msgstr ""
+
 msgid "An email has been sent to the data reviewers"
 msgstr ""
 
@@ -72,6 +79,15 @@ msgstr ""
 msgid ""
 "Are you sure you want to send an email to Data Reviewers asking for "
 "approval?"
+msgstr ""
+
+msgid "Apply to all months"
+msgstr ""
+
+msgid "Applying values to all months..."
+msgstr ""
+
+msgid "Values applied to all months"
 msgstr ""
 
 msgid "Project closed for this period, please contact the administrators"

--- a/src/components/data-entry/DataSetStateButton.tsx
+++ b/src/components/data-entry/DataSetStateButton.tsx
@@ -20,10 +20,6 @@ interface DataSetStateButtonProps {
     dataSetInfo: Maybe<DataSetOpenInfo>;
 }
 
-const applyToAllMonthsMessage = i18n.t(
-    "This action is going to unaproved all the periods. You will have to approve the data again on the Data Approval section. Are you sure you want to apply the current values to all months? The existing data in other months will be overwritten."
-);
-
 const DataSetStateButton: React.FunctionComponent<DataSetStateButtonProps> = props => {
     const [isActive, setActive] = React.useState(false);
     const { api, currentUser, isTest } = useAppContext();
@@ -89,7 +85,9 @@ const DataSetStateButton: React.FunctionComponent<DataSetStateButtonProps> = pro
 
     const openApplyToAllMonthsConfirmation = useConfirmation({
         title: i18n.t("Apply to all months"),
-        text: applyToAllMonthsMessage,
+        text: i18n.t(
+            "This action is going to unapprove all the periods. You will have to approve the data again on the Data Approval section. Are you sure you want to apply the current values to all months? The existing data in other months will be overwritten."
+        ),
         onConfirm: () => {
             loading.show(true, i18n.t("Applying values to all months..."));
             projectDataSet

--- a/src/models/ProjectDataSet.ts
+++ b/src/models/ProjectDataSet.ts
@@ -1,10 +1,16 @@
 import moment, { Moment } from "moment";
 import _ from "lodash";
-import { D2Api, D2DataInputPeriod } from "../types/d2-api";
+import {
+    D2Api,
+    D2DataInputPeriod,
+    DataValueSetsGetResponse,
+    DataValueSetsDataValue,
+} from "../types/d2-api";
 import { Config } from "./Config";
 import Project, { OrganisationUnit, DataSet, DataSetType } from "./Project";
 import ProjectDb, { DataSetOpenAttributes } from "./ProjectDb";
 import { toISOString } from "../utils/date";
+import { promiseMap } from "../migrations/utils";
 
 const monthFormat = "YYYYMM";
 
@@ -131,6 +137,76 @@ export default class ProjectDataSet {
             .get<DataApprovalCategoryOptionCombosResponse>(path, params)
             .getData();
         return dataApprovalsAll.find(da => da.ou === orgUnit.id && da.id === aoc.id);
+    }
+
+    async applyToAllMonths(period: string) {
+        const dataSet = this.getDataSet();
+        const currentDataSetInfo = await this.getOpenInfo(moment(period, monthFormat));
+        await this.reopen({
+            unapprovePeriod: !currentDataSetInfo.isOpenByData ? period : undefined,
+        });
+        const periodsToSearch = this.getOtherPeriods(dataSet, period);
+        const dataValues = await this.getTargetDataValues(dataSet, period);
+        const dataValuesToOverride = this.generateDataValuesForOtherPeriods(
+            periodsToSearch,
+            dataValues
+        );
+        await this.reOpenOtherPeriods(periodsToSearch);
+        await this.saveDataValuesForOtherPeriods(dataValuesToOverride, dataSet);
+    }
+
+    private async saveDataValuesForOtherPeriods(
+        dataValuesToOverride: DataValueSetsDataValue[],
+        dataSet: DataSet
+    ): Promise<void> {
+        await promiseMap(_.chunk(dataValuesToOverride, 100), async dataValuesToSave => {
+            const response = await this.api.dataValues
+                .postSet({}, { dataSet: dataSet.id, dataValues: dataValuesToSave })
+                .getData();
+            if (response.status === "ERROR") {
+                throw Error(response.description);
+            }
+        });
+    }
+
+    private async reOpenOtherPeriods(periodsToSearch: string[]): Promise<void> {
+        await promiseMap(periodsToSearch, async unapprovePeriod => {
+            const dataSetInfo = await this.getOpenInfo(moment(unapprovePeriod, monthFormat));
+            if (!dataSetInfo.isOpenByData) {
+                await this.setApprovalState(unapprovePeriod, false);
+            }
+        });
+    }
+
+    private generateDataValuesForOtherPeriods(
+        periodsToSearch: string[],
+        dataValues: DataValueSetsGetResponse
+    ): DataValueSetsDataValue[] {
+        return _(periodsToSearch)
+            .map(dataSetPeriod => {
+                return dataValues.dataValues.map(d2DataValue => {
+                    return { ...d2DataValue, period: dataSetPeriod };
+                });
+            })
+            .flatMap()
+            .value();
+    }
+
+    private async getTargetDataValues(dataSet: DataSet, period: string) {
+        return await this.api.dataValues
+            .getSet({
+                dataSet: [dataSet.id],
+                period: [period],
+                orgUnit: [this.project.id],
+                attributeOptionCombo: [this.getAttributeOptionCombo().id],
+            })
+            .getData();
+    }
+
+    private getOtherPeriods(dataSet: DataSet, period: string): string[] {
+        return dataSet.dataInputPeriods
+            .filter(inputPeriod => inputPeriod.period.id !== period)
+            .map(inputPeriod => inputPeriod.period.id);
     }
 
     getApprovalForm(period: string) {

--- a/src/models/ProjectDataSet.ts
+++ b/src/models/ProjectDataSet.ts
@@ -183,12 +183,11 @@ export default class ProjectDataSet {
         dataValues: DataValueSetsGetResponse
     ): DataValueSetsDataValue[] {
         return _(periodsToSearch)
-            .map(dataSetPeriod => {
+            .flatMap(dataSetPeriod => {
                 return dataValues.dataValues.map(d2DataValue => {
                     return { ...d2DataValue, period: dataSetPeriod };
                 });
             })
-            .flatMap()
             .value();
     }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/862kjdjxy

### :memo: Implementation

- In order to update the dataValues all the periods are going to be unapproved first, then dataValues can be copied.

### :fire: Notes for the reviewer

### :art: Screenshots

[Data-Management-App.webm](https://github.com/EyeSeeTea/data-management-app/assets/461124/a13dd381-18c2-4459-9f3d-77fde6918967)



