### PR TITLE
Add task analyze (use source-map-explorer)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "xlsx": "^0.18.5"
     },
     "scripts": {
+        "analyze": "source-map-explorer 'build/static/js/*.js'",
         "prestart": "yarn localize && d2-manifest package.json manifest.webapp",
         "start": "react-scripts start",
         "prebuild": "yarn localize && yarn test",
@@ -134,6 +135,7 @@
         "jest": "26.6.3",
         "parse-typed-args": "^0.2.0",
         "prettier": "2.5.1",
+        "source-map-explorer": "^2.5.3",
         "ts-node": "10.9.2",
         "typescript": "4.9.3",
         "wait-on": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
         "styled-components": "^5.2.1",
         "styled-jsx": "3.4.1",
         "use-debounce": "7.0.0",
-        "word-wrap": "1.2.5",
-        "xlsx": "^0.18.5"
+        "word-wrap": "1.2.5"
     },
     "scripts": {
         "analyze": "source-map-explorer 'build/static/js/*.js'",
@@ -138,7 +137,8 @@
         "source-map-explorer": "^2.5.3",
         "ts-node": "10.9.2",
         "typescript": "4.9.3",
-        "wait-on": "5.2.1"
+        "wait-on": "5.2.1",
+        "xlsx": "^0.18.5"
     },
     "manifest.webapp": {
         "name": "Data Management App",

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -1,17 +1,12 @@
 import { DataElementD2Repository } from "./data/repositories/DataElementD2Repository";
 import { DataValueD2Repository } from "./data/repositories/DataValueD2Repository";
-import { DataValueExportJsonRepository } from "./data/repositories/DataValueExportJsonRepository";
-import { ExportDataElementJsonRepository } from "./data/repositories/ExportDataElementJsonRepository";
-import { ImportDataElementSpreadSheetRepository } from "./data/repositories/ImportDataElementSpreadSheetRepository";
 import { IndicatorReportD2Repository } from "./data/repositories/IndicatorReportD2Repository";
-import { OrgUnitD2Repository } from "./data/repositories/OrgUnitD2Repository";
 import { ProjectD2Repository } from "./data/repositories/ProjectD2Repository";
 import { UniqueBeneficiariesSettingsD2Repository } from "./data/repositories/UniqueBeneficiariesSettingsD2Repository";
 import { UniquePeriodD2Repository } from "./data/repositories/UniquePeriodD2Repository";
 import { GetIndicatorsValidationUseCase } from "./domain/usecases/GetIndicatorsValidationUseCase";
 import { GetProjectsByCountryUseCase } from "./domain/usecases/GetProjectsByCountryUseCase";
 import { GetUniqueBeneficiariesSettingsUseCase } from "./domain/usecases/GetUniqueBeneficiariesSettingsUseCase";
-import { ImportDataElementsUseCase } from "./domain/usecases/ImportDataElementsUseCase";
 import { RemoveUniqueBeneficiariesPeriodUseCase } from "./domain/usecases/RemoveUniqueBeneficiariesPeriodUseCase";
 import { SaveIndicatorReportUseCase } from "./domain/usecases/SaveIndicatorReportUseCase";
 import { SaveIndicatorsValidationUseCase } from "./domain/usecases/SaveIndicatorsValidationUseCase";
@@ -23,28 +18,12 @@ export function getCompositionRoot(api: D2Api, config: Config) {
     const uniqueBeneficiariesSettingsRepository = new UniqueBeneficiariesSettingsD2Repository(api);
     const dataValueRepository = new DataValueD2Repository(api);
     const dataElementRepository = new DataElementD2Repository(api, config);
-    const importDataElementSpreadSheetRepository = new ImportDataElementSpreadSheetRepository(
-        api,
-        config
-    );
-    const exportDataElementJsonRepository = new ExportDataElementJsonRepository(api, config);
-    const dataValueExportRepository = new DataValueExportJsonRepository();
-    const orgUnitRepository = new OrgUnitD2Repository(api);
+
     const projectRepository = new ProjectD2Repository(api, config);
     const indicatorReportRepository = new IndicatorReportD2Repository(api, config);
     const periodRepository = new UniquePeriodD2Repository(api);
 
     return {
-        dataElements: {
-            import: new ImportDataElementsUseCase(
-                importDataElementSpreadSheetRepository,
-                dataElementRepository,
-                exportDataElementJsonRepository,
-                dataValueRepository,
-                dataValueExportRepository,
-                orgUnitRepository
-            ),
-        },
         uniqueBeneficiaries: {
             getSettings: new GetUniqueBeneficiariesSettingsUseCase(
                 uniqueBeneficiariesSettingsRepository

--- a/src/scripts/import-data-element-excel.ts
+++ b/src/scripts/import-data-element-excel.ts
@@ -2,7 +2,13 @@ import parse from "parse-typed-args";
 
 import { getApp } from "./common";
 import { getConfig } from "../models/Config";
-import { getCompositionRoot } from "../CompositionRoot";
+import { DataValueExportJsonRepository } from "../data/repositories/DataValueExportJsonRepository";
+import { ExportDataElementJsonRepository } from "../data/repositories/ExportDataElementJsonRepository";
+import { ImportDataElementSpreadSheetRepository } from "../data/repositories/ImportDataElementSpreadSheetRepository";
+import { OrgUnitD2Repository } from "../data/repositories/OrgUnitD2Repository";
+import { ImportDataElementsUseCase } from "../domain/usecases/ImportDataElementsUseCase";
+import { DataElementD2Repository } from "../data/repositories/DataElementD2Repository";
+import { DataValueD2Repository } from "../data/repositories/DataValueD2Repository";
 
 async function main() {
     const parser = parse({
@@ -14,6 +20,7 @@ async function main() {
             deleteDataValues: { switch: true },
         },
     });
+
     const { opts } = parser(process.argv);
 
     if (!opts.url) return;
@@ -22,8 +29,24 @@ async function main() {
     const { api } = await getApp({ baseUrl: opts.url });
     console.info("Loading config. metadata...");
     const config = await getConfig(api);
-    const compositionRoot = getCompositionRoot(api, config);
-    await compositionRoot.dataElements.import.execute({
+
+    const dataValueRepository = new DataValueD2Repository(api);
+    const dataElementRepository = new DataElementD2Repository(api, config);
+    const importRepository = new ImportDataElementSpreadSheetRepository(api, config);
+    const exportDataElementJsonRepository = new ExportDataElementJsonRepository(api, config);
+    const dataValueExportRepository = new DataValueExportJsonRepository();
+    const orgUnitRepository = new OrgUnitD2Repository(api);
+
+    const importDataElementUseCase = new ImportDataElementsUseCase(
+        importRepository,
+        dataElementRepository,
+        exportDataElementJsonRepository,
+        dataValueRepository,
+        dataValueExportRepository,
+        orgUnitRepository
+    );
+
+    await importDataElementUseCase.execute({
         excelPath: opts.excelPath,
         post: opts.post ?? false,
         export: opts.export ?? false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6657,6 +6657,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
@@ -6861,6 +6869,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-buffer@^1.0.0:
   version "1.0.0"
@@ -8236,7 +8253,7 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -8276,6 +8293,13 @@ ejs@^2.6.1:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
+
+ejs@^3.1.5:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
+  dependencies:
+    jake "^10.8.5"
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.649:
   version "1.3.693"
@@ -8571,7 +8595,7 @@ escalade@^3.0.2, escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -9299,6 +9323,13 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+filelist@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
+  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+  dependencies:
+    minimatch "^5.0.1"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -9695,7 +9726,7 @@ gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -9941,6 +9972,13 @@ gzip-size@5.1.1:
   dependencies:
     duplexer "^0.1.1"
     pify "^4.0.1"
+
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
 
 handle-thing@^2.0.0:
   version "2.0.1"
@@ -11331,6 +11369,16 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jake@^10.8.5:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.2.tgz#6ae487e6a69afec3a5e167628996b59f35ae2b7f"
+  integrity sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
+    filelist "^1.0.4"
+    minimatch "^3.1.2"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"
@@ -12840,7 +12888,14 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.1.0:
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -13438,7 +13493,7 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^7.0.2:
+open@^7.0.2, open@^7.3.1:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -15798,6 +15853,13 @@ rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -16340,6 +16402,24 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-explorer@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-explorer/-/source-map-explorer-2.5.3.tgz#33551b51e33b70f56d15e79083cdd4c43e583b69"
+  integrity sha512-qfUGs7UHsOBE5p/lGfQdaAj/5U/GWYBw2imEpD6UQNkqElYonkow8t+HBL1qqIl3CuGZx7n8/CQo4x1HwSHhsg==
+  dependencies:
+    btoa "^1.2.1"
+    chalk "^4.1.0"
+    convert-source-map "^1.7.0"
+    ejs "^3.1.5"
+    escape-html "^1.0.3"
+    glob "^7.1.6"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    open "^7.3.1"
+    source-map "^0.7.4"
+    temp "^0.9.4"
+    yargs "^16.2.0"
+
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -16385,6 +16465,11 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"
@@ -16953,6 +17038,14 @@ temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
+
+temp@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
+  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
+  dependencies:
+    mkdirp "^0.5.1"
+    rimraf "~2.6.2"
 
 tempy@^0.3.0:
   version "0.3.0"
@@ -18295,6 +18388,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -18360,6 +18462,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -18398,6 +18505,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs@^13.3.2:
   version "13.3.2"
@@ -18448,6 +18560,19 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Add task to analyze the build size of the package

### :memo: Implementation

- Add package source-map-explorer 
- Add task "analyze"

### :fire: Notes for the reviewer

Example for HTML output (a page will be open in a browser)::

```
$ yarn analyze
```

Example for TSV output:

```
$ yarn analyze --tsv |& grep node_modules | head -n10
../node_modules/exceljs/dist/exceljs.min.js	1165355
../node_modules/@eyeseetea/d2-api/2.36/schemas.js	415692
../node_modules/xlsx/xlsx.mjs	328005
../node_modules/react-dom/cjs/react-dom.production.min.js	118664
../node_modules/lodash/lodash.js	71604
../node_modules/@eyeseetea/d2-ui-components/node_modules/lodash/lodash.js	71403
../node_modules/lodash/lodash.min.js	70900
../node_modules/@eyeseetea/feedback-component/node_modules/moment/moment.js	60318
../node_modules/moment/moment.js	60229
../node_modules/@eyeseetea/d2-api/node_modules/iconv-lite/encodings/sbcs-data-generated.js	57519
```

From here we can start an analysis of the packages, for example: 

```$ git blame package.json | grep "exceljs\|xlsx"
24c354c1 (Eduardo Peredo Rivero 2023-07-28 12:21:07 -0500  36)         "exceljs": "4.3.0",
247f3c3d (Eduardo Peredo Rivero 2024-02-10 15:55:56 -0500  57)         "xlsx": "^0.18.5"
```

The schemas thing with d2-api is a known problem, but we've had no time to see how to solve it.