### PR TITLE
add year for indicators validation and unique beneficiaries report

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-11-18T23:17:59.995Z\n"
-"PO-Revision-Date: 2024-11-18T23:17:59.995Z\n"
+"POT-Creation-Date: 2024-11-19T17:41:51.262Z\n"
+"PO-Revision-Date: 2024-11-19T17:41:51.262Z\n"
 
 msgid "Validating Project"
 msgstr ""
@@ -885,10 +885,10 @@ msgstr ""
 msgid "Country Project & Indicators"
 msgstr ""
 
-msgid "Select period"
+msgid "Select Year"
 msgstr ""
 
-msgid "Select Year"
+msgid "Select period"
 msgstr ""
 
 msgid "No projects found for selected period: {{period}}"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-11-13T15:09:53.588Z\n"
-"PO-Revision-Date: 2024-11-13T15:09:53.588Z\n"
+"POT-Creation-Date: 2024-11-18T23:17:59.995Z\n"
+"PO-Revision-Date: 2024-11-18T23:17:59.995Z\n"
 
 msgid "Validating Project"
 msgstr ""
@@ -888,6 +888,9 @@ msgstr ""
 msgid "Select period"
 msgstr ""
 
+msgid "Select Year"
+msgstr ""
+
 msgid "No projects found for selected period: {{period}}"
 msgstr ""
 
@@ -1012,7 +1015,7 @@ msgstr ""
 msgid "Project Indicators Validation"
 msgstr ""
 
-msgid "Select a Period"
+msgid "Select Period"
 msgstr ""
 
 msgid "Unique in Project"
@@ -1037,6 +1040,9 @@ msgid "Saving Indicators..."
 msgstr ""
 
 msgid "Indicators saved"
+msgstr ""
+
+msgid "Loading Project"
 msgstr ""
 
 msgid "Loading Indicators..."

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-11-20T14:50:17.120Z\n"
-"PO-Revision-Date: 2024-11-20T14:50:17.120Z\n"
+"POT-Creation-Date: 2024-11-20T15:06:33.223Z\n"
+"PO-Revision-Date: 2024-11-20T15:06:33.223Z\n"
 
 msgid "Validating Project"
 msgstr ""
@@ -1093,6 +1093,14 @@ msgid "Clone project"
 msgstr ""
 
 msgid "New project"
+msgstr ""
+
+msgid ""
+"Please review all prefilled information including Project numbers and dates "
+"which MUST be updated."
+msgstr ""
+
+msgid "OK"
 msgstr ""
 
 msgid ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-11-19T17:41:51.262Z\n"
-"PO-Revision-Date: 2024-11-19T17:41:51.262Z\n"
+"POT-Creation-Date: 2024-11-20T14:50:17.120Z\n"
+"PO-Revision-Date: 2024-11-20T14:50:17.120Z\n"
 
 msgid "Validating Project"
 msgstr ""
@@ -1063,13 +1063,10 @@ msgstr ""
 msgid "Country & Project Locations"
 msgstr ""
 
-msgid "Selection of Indicators"
+msgid "Indicators"
 msgstr ""
 
-msgid "Selection of MER Indicators"
-msgstr ""
-
-msgid "Select of Unique Indicators"
+msgid "MER Indicators"
 msgstr ""
 
 msgid "Username Access"

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -9,6 +9,7 @@ import { ProjectD2Repository } from "./data/repositories/ProjectD2Repository";
 import { UniqueBeneficiariesSettingsD2Repository } from "./data/repositories/UniqueBeneficiariesSettingsD2Repository";
 import { UniquePeriodD2Repository } from "./data/repositories/UniquePeriodD2Repository";
 import { GetIndicatorsValidationUseCase } from "./domain/usecases/GetIndicatorsValidationUseCase";
+import { GetProjectByIdUseCase } from "./domain/usecases/GetProjectByIdUseCase";
 import { GetProjectsByCountryUseCase } from "./domain/usecases/GetProjectsByCountryUseCase";
 import { GetUniqueBeneficiariesSettingsUseCase } from "./domain/usecases/GetUniqueBeneficiariesSettingsUseCase";
 import { ImportDataElementsUseCase } from "./domain/usecases/ImportDataElementsUseCase";
@@ -20,7 +21,10 @@ import { Config } from "./models/Config";
 import { D2Api } from "./types/d2-api";
 
 export function getCompositionRoot(api: D2Api, config: Config) {
-    const uniqueBeneficiariesSettingsRepository = new UniqueBeneficiariesSettingsD2Repository(api);
+    const uniqueBeneficiariesSettingsRepository = new UniqueBeneficiariesSettingsD2Repository(
+        api,
+        config
+    );
     const dataValueRepository = new DataValueD2Repository(api);
     const dataElementRepository = new DataElementD2Repository(api, config);
     const importDataElementSpreadSheetRepository = new ImportDataElementSpreadSheetRepository(
@@ -32,7 +36,7 @@ export function getCompositionRoot(api: D2Api, config: Config) {
     const orgUnitRepository = new OrgUnitD2Repository(api);
     const projectRepository = new ProjectD2Repository(api, config);
     const indicatorReportRepository = new IndicatorReportD2Repository(api, config);
-    const periodRepository = new UniquePeriodD2Repository(api);
+    const periodRepository = new UniquePeriodD2Repository(api, config);
 
     return {
         dataElements: {
@@ -65,6 +69,7 @@ export function getCompositionRoot(api: D2Api, config: Config) {
             saveReports: new SaveIndicatorReportUseCase(indicatorReportRepository),
         },
         projects: {
+            getById: new GetProjectByIdUseCase(projectRepository),
             getByCountry: new GetProjectsByCountryUseCase(
                 projectRepository,
                 uniqueBeneficiariesSettingsRepository,

--- a/src/data/common/D2ApiProject.ts
+++ b/src/data/common/D2ApiProject.ts
@@ -1,0 +1,63 @@
+import { ProjectCountry } from "../../domain/entities/IndicatorReport";
+import { Config } from "../../models/Config";
+import Project, { getDatesFromOrgUnit } from "../../models/Project";
+import { ProjectForList } from "../../models/ProjectsList";
+import { D2Api, Id } from "../../types/d2-api";
+
+export class D2ApiProject {
+    constructor(private api: D2Api, private config: Config) {}
+
+    async getByIds(ids: string[]): Promise<ProjectCountry[]> {
+        if (ids.length === 0) return [];
+
+        const response = await this.api.models.organisationUnits
+            .get({
+                fields: {
+                    id: true,
+                    code: true,
+                    name: true,
+                    displayName: true,
+                    openingDate: true,
+                    closedDate: true,
+                },
+                paging: false,
+                filter: { id: { in: ids } },
+            })
+            .getData();
+
+        return response.objects.map((d2OrgUnit): ProjectCountry => {
+            const { startDate, endDate } = getDatesFromOrgUnit(d2OrgUnit);
+            return {
+                closedDate: endDate?.toISOString() || "",
+                id: d2OrgUnit.id,
+                name: d2OrgUnit.displayName,
+                openingDate: startDate?.toISOString() || "",
+            };
+        });
+    }
+
+    async getAllProjectsByCountry(
+        countryId: Id,
+        initialPage: number,
+        initialProjects: ProjectForList[]
+    ) {
+        const response = await this.getByCountry(countryId, initialPage);
+        const newProjects = [...initialProjects, ...response.objects];
+        if (response.pager.page >= response.pager.pageCount) {
+            return newProjects;
+        } else {
+            const projects = await this.getByCountry(countryId, initialPage + 1);
+            return projects.objects;
+        }
+    }
+
+    private getByCountry(countryId: Id, page: number) {
+        return Project.getList(
+            this.api,
+            this.config,
+            { countryIds: [countryId], onlyActive: true },
+            { field: "created", order: "desc" },
+            { page: page, pageSize: 50 }
+        );
+    }
+}

--- a/src/data/repositories/IndicatorReportD2Repository.ts
+++ b/src/data/repositories/IndicatorReportD2Repository.ts
@@ -3,33 +3,36 @@ import { D2Api, DataStore } from "../../types/d2-api";
 import {
     IndicatorReport,
     IndicatorReportToSave,
-    ProjectCountry,
+    ProjectIndicatorRow,
 } from "../../domain/entities/IndicatorReport";
 import { IndicatorReportRepository } from "../../domain/repositories/IndicatorReportRepository";
 import { DATA_MANAGEMENT_NAMESPACE } from "../common";
 import { Id, ISODateTimeString } from "../../domain/entities/Ref";
 import { D2ApiUbSettings } from "../common/D2ApiUbSettings";
-import Project from "../../models/Project";
-import { promiseMap } from "../../migrations/utils";
 import { Config } from "../../models/Config";
 import { UniqueBeneficiariesPeriod } from "../../domain/entities/UniqueBeneficiariesPeriod";
 import { D2DataElement } from "./D2DataElement";
+import { D2ApiProject } from "../common/D2ApiProject";
+import { UniqueBeneficiariesSettings } from "../../domain/entities/UniqueBeneficiariesSettings";
+import { DataElement } from "../../domain/entities/DataElement";
 
 export class IndicatorReportD2Repository implements IndicatorReportRepository {
     private prefixKey = "ubreport";
     private dataStore: DataStore;
     private d2ApiUbSettings: D2ApiUbSettings;
     private d2ApiDataElement: D2DataElement;
+    private d2ApiProject: D2ApiProject;
 
     constructor(private api: D2Api, private config: Config) {
         this.dataStore = this.api.dataStore(DATA_MANAGEMENT_NAMESPACE);
-        this.d2ApiUbSettings = new D2ApiUbSettings(this.api);
+        this.d2ApiUbSettings = new D2ApiUbSettings(this.api, config);
         this.d2ApiDataElement = new D2DataElement(this.api, this.config);
+        this.d2ApiProject = new D2ApiProject(api, config);
     }
 
     async getByCountry(countryId: Id): Promise<IndicatorReport[]> {
         const response = await this.dataStore.get<D2Response[]>(this.buildKey(countryId)).getData();
-        return this.buildReportsFromResponse(response || []);
+        return this.buildReportsFromResponse(response || [], countryId);
     }
 
     async save(reports: IndicatorReportToSave[], countryId: Id): Promise<void> {
@@ -53,6 +56,7 @@ export class IndicatorReportD2Repository implements IndicatorReportRepository {
             );
 
             return {
+                year: report.year,
                 countryId: report.countryId,
                 createdAt: existingRecord?.createdAt || currentDate,
                 updatedAt: currentDate,
@@ -71,14 +75,19 @@ export class IndicatorReportD2Repository implements IndicatorReportRepository {
         });
     }
 
-    private async buildReportsFromResponse(responses: D2Response[]): Promise<IndicatorReport[]> {
-        const projectIds = responses.flatMap(item => item.projects.map(project => project.id));
-        const projects = await this.getProjectsByIds(projectIds);
-        const settings = await this.d2ApiUbSettings.getAll();
+    private async buildReportsFromResponse(
+        responses: D2Response[],
+        countryId: Id
+    ): Promise<IndicatorReport[]> {
+        const projectResponse = await this.d2ApiProject.getAllProjectsByCountry(countryId, 1, []);
+
+        const projectsIds = projectResponse.map(item => item.id);
+        const projects = await this.d2ApiProject.getByIds(projectsIds);
+        const settings = await this.d2ApiUbSettings.getAll({ projectsIds });
         const dataElementsIds = settings.flatMap(setting => setting.indicatorsIds);
         const dataElements = await this.d2ApiDataElement.getByIds(dataElementsIds);
         const settingsByProjects = settings.filter(setting =>
-            projectIds.includes(setting.projectId)
+            projectsIds.includes(setting.projectId)
         );
         const periods = settingsByProjects.flatMap(setting => setting.periods);
         const groupedPeriods = UniqueBeneficiariesPeriod.uniquePeriodsByDates(periods);
@@ -91,33 +100,32 @@ export class IndicatorReportD2Repository implements IndicatorReportRepository {
                 throw Error(`Period ${response.startDate}-${response.endDate} not found`);
 
             return IndicatorReport.create({
+                year: response.year,
                 countryId: response.countryId,
                 createdAt: response.createdAt,
                 lastUpdatedAt: response.updatedAt,
                 period: currentPeriod,
-                projects: _(response.projects)
+                projects: _(projects)
                     .map(project => {
-                        const projectDetails = projects.find(
-                            projectDetail => projectDetail.id === project.id
+                        const projectResult = response.projects.find(
+                            item => item.id === project.id
                         );
-                        if (!projectDetails) return undefined;
 
                         return {
                             id: project.id,
-                            indicators: project.indicators.map(indicator => {
-                                const dataElementDetails = dataElements.find(
-                                    dataElement => dataElement.id === indicator.indicatorId
-                                );
-                                return {
-                                    include: indicator.include,
-                                    indicatorId: indicator.indicatorId,
-                                    indicatorCode: dataElementDetails?.code || "",
-                                    indicatorName: dataElementDetails?.name || "",
-                                    value: indicator.value,
-                                    periodNotAvailable: indicator.periodNotAvailable,
-                                };
-                            }),
-                            project: projectDetails,
+                            indicators: projectResult?.indicators
+                                ? this.buildExistingIndicators(projectResult, dataElements)
+                                : this.buildIndicators(
+                                      settingsByProjects,
+                                      project.id,
+                                      dataElements
+                                  ),
+                            project: {
+                                id: project.id,
+                                name: project.name,
+                                openingDate: project.openingDate,
+                                closedDate: project.closedDate,
+                            },
                         };
                     })
                     .compact()
@@ -126,14 +134,47 @@ export class IndicatorReportD2Repository implements IndicatorReportRepository {
         });
     }
 
-    private async getProjectsByIds(projectIds: Id[]): Promise<ProjectCountry[]> {
-        const projects = await promiseMap(projectIds, id => Project.get(this.api, this.config, id));
-        return projects.map(project => ({
-            id: project.id,
-            name: project.name,
-            openingDate: project.startDate?.toISOString() || "",
-            closedDate: project.endDate?.toISOString() || "",
-        }));
+    private buildExistingIndicators(
+        projectResult: D2Response["projects"][number],
+        dataElements: DataElement[]
+    ): ProjectIndicatorRow[] {
+        return _(projectResult.indicators)
+            .map(indicator => {
+                const dataElementDetails = dataElements.find(
+                    dataElement => dataElement.id === indicator.indicatorId
+                );
+                return {
+                    include: indicator.include,
+                    indicatorId: indicator.indicatorId,
+                    indicatorCode: dataElementDetails?.code || "",
+                    indicatorName: dataElementDetails?.name || "",
+                    value: indicator.value,
+                    periodNotAvailable: indicator.periodNotAvailable,
+                };
+            })
+            .value();
+    }
+
+    private buildIndicators(
+        settings: UniqueBeneficiariesSettings[],
+        projectId: Id,
+        dataElements: DataElement[]
+    ): ProjectIndicatorRow[] {
+        const projectSettings = settings.find(setting => setting.projectId === projectId);
+        const indicatorsIds = projectSettings?.indicatorsIds || [];
+        return indicatorsIds.map((indicatorId): ProjectIndicatorRow => {
+            const dataElementDetails = dataElements.find(
+                dataElement => dataElement.id === indicatorId
+            );
+            return {
+                include: false,
+                indicatorCode: dataElementDetails?.code || "",
+                indicatorName: dataElementDetails?.name || "",
+                indicatorId: indicatorId,
+                value: 0,
+                periodNotAvailable: false,
+            };
+        });
     }
 
     private buildKey(countryId: Id) {
@@ -147,6 +188,7 @@ type D2Response = {
     endDate: number;
     createdAt: ISODateTimeString;
     updatedAt: ISODateTimeString;
+    year: number;
     projects: Array<{
         id: Id;
         indicators: Array<{

--- a/src/data/repositories/ProjectD2Repository.ts
+++ b/src/data/repositories/ProjectD2Repository.ts
@@ -4,40 +4,20 @@ import { Config } from "../../models/Config";
 import Project from "../../models/Project";
 import { ProjectForList } from "../../models/ProjectsList";
 import { D2Api } from "../../types/d2-api";
+import { D2ApiProject } from "../common/D2ApiProject";
 
 export class ProjectD2Repository implements ProjectRepository {
-    constructor(private api: D2Api, private config: Config) {}
+    private d2ApiProject: D2ApiProject;
+
+    constructor(private api: D2Api, private config: Config) {
+        this.d2ApiProject = new D2ApiProject(api, config);
+    }
 
     async getById(id: Id): Promise<Project> {
         return Project.get(this.api, this.config, id);
     }
 
     async getByCountries(countryId: Id): Promise<ProjectForList[]> {
-        return this.getAllProjectsByCountry(countryId, 1, []);
-    }
-
-    private async getAllProjectsByCountry(
-        countryId: Id,
-        initialPage: number,
-        initialProjects: ProjectForList[]
-    ) {
-        const response = await this.getByCountry(countryId, initialPage);
-        const newProjects = [...initialProjects, ...response.objects];
-        if (response.pager.page >= response.pager.pageCount) {
-            return newProjects;
-        } else {
-            const projects = await this.getByCountry(countryId, initialPage + 1);
-            return projects.objects;
-        }
-    }
-
-    private getByCountry(countryId: Id, page: number) {
-        return Project.getList(
-            this.api,
-            this.config,
-            { countryIds: [countryId], onlyActive: true },
-            { field: "created", order: "desc" },
-            { page: page, pageSize: 50 }
-        );
+        return this.d2ApiProject.getAllProjectsByCountry(countryId, 1, []);
     }
 }

--- a/src/data/repositories/UniqueBeneficiariesSettingsD2Repository.ts
+++ b/src/data/repositories/UniqueBeneficiariesSettingsD2Repository.ts
@@ -1,7 +1,9 @@
 import { Id } from "../../domain/entities/Ref";
 import { UniqueBeneficiariesSettings } from "../../domain/entities/UniqueBeneficiariesSettings";
 import { UniqueBeneficiariesSettingsRepository } from "../../domain/repositories/UniqueBeneficiariesSettingsRepository";
+import { Config } from "../../models/Config";
 import { D2Api } from "../../types/d2-api";
+import { Maybe } from "../../types/utils";
 import { D2ApiUbSettings } from "../common/D2ApiUbSettings";
 
 export class UniqueBeneficiariesSettingsD2Repository
@@ -9,12 +11,12 @@ export class UniqueBeneficiariesSettingsD2Repository
 {
     private d2ApiUbSettings: D2ApiUbSettings;
 
-    constructor(private api: D2Api) {
-        this.d2ApiUbSettings = new D2ApiUbSettings(this.api);
+    constructor(private api: D2Api, private config: Config) {
+        this.d2ApiUbSettings = new D2ApiUbSettings(this.api, this.config);
     }
 
-    async getAll(): Promise<UniqueBeneficiariesSettings[]> {
-        return this.d2ApiUbSettings.getAll();
+    async getAll(options: { projectsIds: Maybe<Id[]> }): Promise<UniqueBeneficiariesSettings[]> {
+        return this.d2ApiUbSettings.getAll(options);
     }
 
     async get(projectId: Id): Promise<UniqueBeneficiariesSettings> {

--- a/src/data/repositories/UniquePeriodD2Repository.ts
+++ b/src/data/repositories/UniquePeriodD2Repository.ts
@@ -8,15 +8,16 @@ import { DATA_MANAGEMENT_NAMESPACE } from "../common";
 import { Id } from "../../domain/entities/Ref";
 import { D2ApiUbSettings } from "../common/D2ApiUbSettings";
 import { generateUid } from "d2/uid";
+import { Config } from "../../models/Config";
 
 export class UniquePeriodD2Repository implements UniquePeriodRepository {
     private dataStore: DataStore;
     private namespace = DATA_MANAGEMENT_NAMESPACE;
     private d2ApiUbSettings: D2ApiUbSettings;
 
-    constructor(private api: D2Api) {
+    constructor(private api: D2Api, config: Config) {
         this.dataStore = this.api.dataStore(this.namespace);
-        this.d2ApiUbSettings = new D2ApiUbSettings(this.api);
+        this.d2ApiUbSettings = new D2ApiUbSettings(this.api, config);
     }
 
     async getByProject(projectId: Id): Promise<UniqueBeneficiariesPeriod[]> {

--- a/src/domain/entities/IndicatorReport.tsx
+++ b/src/domain/entities/IndicatorReport.tsx
@@ -10,6 +10,7 @@ export type IndicatorReportAttrs = {
     createdAt: ISODateTimeString;
     lastUpdatedAt: ISODateTimeString;
     projects: ProjectRows[];
+    year: number;
 };
 
 export type IndicatorReportToSave = Omit<IndicatorReportAttrs, "createdAt" | "lastUpdatedAt">;
@@ -44,6 +45,10 @@ export class IndicatorReport extends Struct<IndicatorReportAttrs>() {
                 : project;
         });
         return this._update({ projects: newProjects });
+    }
+
+    checkPeriodAndYear(periodId: Id, year: number): boolean {
+        return this.period.id === periodId && this.year === year;
     }
 
     private updateIndicators(

--- a/src/domain/repositories/UniqueBeneficiariesSettingsRepository.ts
+++ b/src/domain/repositories/UniqueBeneficiariesSettingsRepository.ts
@@ -1,8 +1,9 @@
+import { Maybe } from "../../types/utils";
 import { Id } from "../entities/Ref";
 import { UniqueBeneficiariesSettings } from "../entities/UniqueBeneficiariesSettings";
 
 export interface UniqueBeneficiariesSettingsRepository {
     get(projectId: Id): Promise<UniqueBeneficiariesSettings>;
     save(settings: UniqueBeneficiariesSettings): Promise<void>;
-    getAll(): Promise<UniqueBeneficiariesSettings[]>;
+    getAll(options: { projectsIds: Maybe<Id[]> }): Promise<UniqueBeneficiariesSettings[]>;
 }

--- a/src/domain/usecases/GetIndicatorsValidationUseCase.ts
+++ b/src/domain/usecases/GetIndicatorsValidationUseCase.ts
@@ -1,9 +1,7 @@
-import _ from "lodash";
 import i18n from "../../locales";
 import { promiseMap } from "../../migrations/utils";
 import { Config } from "../../models/Config";
 import Project from "../../models/Project";
-import { getYearsFromProject } from "../../pages/project-indicators-validation/ProjectIndicatorsValidation";
 import { DataValue } from "../entities/DataValue";
 import { IndicatorCalculation } from "../entities/IndicatorCalculation";
 import { IndicatorValidation } from "../entities/IndicatorValidation";
@@ -74,25 +72,6 @@ export class GetIndicatorsValidationUseCase {
         });
 
         return indicatorsWithValues;
-    }
-
-    private getPeriodsAndYearsFromProject(project: Project, periods: UniqueBeneficiariesPeriod[]) {
-        const years = getYearsFromProject(
-            project.startDate?.toISOString() || "",
-            project.endDate?.toISOString() || ""
-        );
-        const periodsByYears = _(years)
-            .flatMap(year =>
-                periods.map(period => ({
-                    key: `${year}-${period.id}`,
-                    value: { period, year },
-                }))
-            )
-            .keyBy("key")
-            .mapValues("value")
-            .value();
-
-        return { years, periodsByYears };
     }
 
     private async setValuesToIndicators(

--- a/src/domain/usecases/GetProjectByIdUseCase.ts
+++ b/src/domain/usecases/GetProjectByIdUseCase.ts
@@ -1,0 +1,11 @@
+import Project from "../../models/Project";
+import { Id } from "../entities/Ref";
+import { ProjectRepository } from "../repositories/ProjectRepository";
+
+export class GetProjectByIdUseCase {
+    constructor(private projectRepository: ProjectRepository) {}
+
+    execute(id: Id): Promise<Project> {
+        return this.projectRepository.getById(id);
+    }
+}

--- a/src/domain/usecases/SaveIndicatorsValidationUseCase.ts
+++ b/src/domain/usecases/SaveIndicatorsValidationUseCase.ts
@@ -51,8 +51,8 @@ export class SaveIndicatorsValidationUseCase {
         settings: UniqueBeneficiariesSettings
     ): IndicatorValidation[] {
         return indicatorsValidations.map(indicator => {
-            const indicatorExist = settings.indicatorsValidation.find(
-                item => item.period.id === indicator.period.id
+            const indicatorExist = settings.indicatorsValidation.find(item =>
+                item.checkPeriodAndYear(indicator.period.id, indicator.year)
             );
 
             const currentDate = new Date().toISOString();

--- a/src/pages/country-indicator-report/CountryIndicatorReport.tsx
+++ b/src/pages/country-indicator-report/CountryIndicatorReport.tsx
@@ -1,5 +1,12 @@
+import _ from "lodash";
 import React from "react";
-import { ConfirmationDialog, Dropdown, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import {
+    ConfirmationDialog,
+    Dropdown,
+    useLoading,
+    useSnackbar,
+    DropdownItem,
+} from "@eyeseetea/d2-ui-components";
 import { Button, Grid, Typography } from "@material-ui/core";
 
 import UserOrgUnits, { OrganisationUnit } from "../../components/org-units/UserOrgUnits";
@@ -16,10 +23,12 @@ import { buildSpreadSheet } from "./excel-report";
 import { downloadFile } from "../../utils/download";
 import { useConfirmChanges } from "../report/MerReport";
 import { UniqueBeneficiariesSettings } from "../../domain/entities/UniqueBeneficiariesSettings";
+import { getYearsFromProject } from "../project-indicators-validation/ProjectIndicatorsValidation";
 
 export const CountryIndicatorReport = React.memo(() => {
     const goTo = useGoTo();
     const [orgUnit, setOrgUnit] = React.useState<OrganisationUnit>();
+    const [year, setYear] = React.useState<number>();
     const [selectedPeriod, setSelectedPeriod] = React.useState<UniqueBeneficiariesPeriod>();
     const { confirmIfUnsavedChanges, proceedWarning, runProceedAction, wasReportModifiedSet } =
         useConfirmChanges();
@@ -49,24 +58,30 @@ export const CountryIndicatorReport = React.memo(() => {
         }
     };
 
+    const updateYear = (year: Maybe<string>) => {
+        if (year) setYear(Number(year));
+    };
+
     const updateReport = React.useCallback(
         (value: boolean, row: GroupedRows) => {
-            if (!selectedPeriod) return;
+            if (!selectedPeriod || !year) return;
 
             const updatedIndicators = indicatorsReports.map(indicatorReport => {
-                if (indicatorReport.period.id !== selectedPeriod.id) return indicatorReport;
+                if (!indicatorReport.checkPeriodAndYear(selectedPeriod.id, year))
+                    return indicatorReport;
 
                 return indicatorReport.updateProjectIndicators(row.project.id, row.id, value);
             });
             setIndicatorsReports(updatedIndicators);
             wasReportModifiedSet(true);
         },
-        [indicatorsReports, selectedPeriod, setIndicatorsReports, wasReportModifiedSet]
+        [indicatorsReports, selectedPeriod, setIndicatorsReports, wasReportModifiedSet, year]
     );
 
-    const indicatorReport = indicatorsReports.find(
-        report => report.period.id === selectedPeriod?.id
-    );
+    const indicatorReport =
+        year && selectedPeriod
+            ? indicatorsReports.find(report => report.checkPeriodAndYear(selectedPeriod.id, year))
+            : undefined;
 
     const downloadReport = () => {
         if (indicatorReport && orgUnit && selectedPeriod) {
@@ -88,6 +103,8 @@ export const CountryIndicatorReport = React.memo(() => {
     const reportHasProjects = indicatorReport && indicatorReport.projects.length > 0;
     const titlePage = i18n.t("Country Project & Indicators");
 
+    const years = mapYearsToItems(indicatorsReports);
+
     return (
         <section>
             <PageHeader title={i18n.t("Country Project & Indicators")} onBackClick={changePage} />
@@ -102,16 +119,25 @@ export const CountryIndicatorReport = React.memo(() => {
                         height={200}
                     />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid item>
                     <Dropdown
                         items={mapItemsToDropdown(getAllPeriods(indicatorsReports))}
-                        onChange={period => updatePeriod(period)}
+                        onChange={updatePeriod}
                         label={i18n.t("Select period")}
                         value={selectedPeriod?.id}
                         hideEmpty
                     />
                 </Grid>
-                {reportHasProjects && selectedPeriod && (
+                <Grid item>
+                    <Dropdown
+                        items={years}
+                        onChange={updateYear}
+                        label={i18n.t("Select Year")}
+                        value={year?.toString()}
+                        hideEmpty
+                    />
+                </Grid>
+                {reportHasProjects && selectedPeriod && year && (
                     <>
                         <Grid item xs={12}>
                             <IndicatorReportTable
@@ -147,7 +173,7 @@ export const CountryIndicatorReport = React.memo(() => {
                         </Grid>
                     </>
                 )}
-                {selectedPeriod && !reportHasProjects && (
+                {selectedPeriod && year && !reportHasProjects && (
                     <Typography>
                         {i18n.t("No projects found for selected period: {{period}}", {
                             nsSeparator: false,
@@ -176,8 +202,28 @@ export const CountryIndicatorReport = React.memo(() => {
 
 CountryIndicatorReport.displayName = "CountryIndicatorReport";
 
+function getUniqueYearsFromProjects(indicatorsReports: IndicatorReport[]): number[] {
+    return _(indicatorsReports)
+        .flatMap(report =>
+            report.projects.map(project => {
+                return getYearsFromProject(project.project.openingDate, project.project.closedDate);
+            })
+        )
+        .flatten()
+        .uniq()
+        .value();
+}
+
+function mapYearsToItems(indicatorsReports: IndicatorReport[]): DropdownItem[] {
+    const years = getUniqueYearsFromProjects(indicatorsReports);
+    return years.map(year => ({ text: year.toString(), value: year.toString() }));
+}
+
 function getAllPeriods(indicatorsReports: IndicatorReport[]): UniqueBeneficiariesPeriod[] {
-    return indicatorsReports.flatMap(setting => setting.period);
+    return _(indicatorsReports)
+        .flatMap(setting => setting.period)
+        .uniqBy(period => period.name)
+        .value();
 }
 
 function mapItemsToDropdown(periods: UniqueBeneficiariesPeriod[]) {

--- a/src/pages/country-indicator-report/CountryIndicatorReport.tsx
+++ b/src/pages/country-indicator-report/CountryIndicatorReport.tsx
@@ -121,19 +121,19 @@ export const CountryIndicatorReport = React.memo(() => {
                 </Grid>
                 <Grid item>
                     <Dropdown
-                        items={mapItemsToDropdown(getAllPeriods(indicatorsReports))}
-                        onChange={updatePeriod}
-                        label={i18n.t("Select period")}
-                        value={selectedPeriod?.id}
+                        items={years}
+                        onChange={updateYear}
+                        label={i18n.t("Select Year")}
+                        value={year?.toString()}
                         hideEmpty
                     />
                 </Grid>
                 <Grid item>
                     <Dropdown
-                        items={years}
-                        onChange={updateYear}
-                        label={i18n.t("Select Year")}
-                        value={year?.toString()}
+                        items={mapItemsToDropdown(getAllPeriods(indicatorsReports))}
+                        onChange={updatePeriod}
+                        label={i18n.t("Select period")}
+                        value={selectedPeriod?.id}
                         hideEmpty
                     />
                 </Grid>

--- a/src/pages/country-indicator-report/CountryIndicatorReport.tsx
+++ b/src/pages/country-indicator-report/CountryIndicatorReport.tsx
@@ -84,12 +84,13 @@ export const CountryIndicatorReport = React.memo(() => {
             : undefined;
 
     const downloadReport = () => {
-        if (indicatorReport && orgUnit && selectedPeriod) {
+        if (indicatorReport && orgUnit && selectedPeriod && year) {
             buildSpreadSheet({
                 indicatorReport,
                 countryName: orgUnit.displayName,
                 period: selectedPeriod,
                 settings,
+                year,
             }).then(downloadFile);
         }
     };

--- a/src/pages/country-indicator-report/IndicatorReportTable.tsx
+++ b/src/pages/country-indicator-report/IndicatorReportTable.tsx
@@ -115,13 +115,14 @@ const ProjectCell = (props: ProjectCellProps) => {
     const { period, rowSpan, row, settings } = props;
 
     const currentPeriod = getCurrentPeriodForProject(settings, row.project.id, period);
+    const periodName = `Period: ${currentPeriod?.name || getNotAvailableText()}`;
 
     return (
         <TableCell rowSpan={rowSpan}>
             {row.project.name} <br /> ({buildMonthYearFormatDate(row.project.openingDate)} -{" "}
             {buildMonthYearFormatDate(row.project.closedDate)})
             <br />
-            Period: {currentPeriod?.name || i18n.t("N/A")}
+            {row.periodNotAvailable ? getNotAvailableText() : periodName}
         </TableCell>
     );
 };
@@ -129,13 +130,13 @@ const ProjectCell = (props: ProjectCellProps) => {
 const TotalCell: RowComponent<GroupedRows> = props => {
     return (
         <TableCell rowSpan={props.rowSpan}>
-            {props.row.periodNotAvailable ? i18n.t("N/A") : props.row.total}
+            {props.row.periodNotAvailable ? getNotAvailableText() : props.row.total}
         </TableCell>
     );
 };
 
 const IndicatorCell = (props: IndicatorCellProps) => {
-    const notAvailableText = i18n.t("N/A");
+    const notAvailableText = getNotAvailableText();
     const isPeriodNotAvailable = props.row.periodNotAvailable;
 
     return (
@@ -194,4 +195,8 @@ export function getCurrentPeriodForProject(
         projectPeriod.equalMonths(period.startDateMonth, period.endDateMonth)
     );
     return currentPeriod;
+}
+
+function getNotAvailableText() {
+    return i18n.t("N/A");
 }

--- a/src/pages/country-indicator-report/excel-report.ts
+++ b/src/pages/country-indicator-report/excel-report.ts
@@ -12,24 +12,26 @@ type SpreadSheetOptions = {
     countryName: string;
     settings: UniqueBeneficiariesSettings[];
     period: UniqueBeneficiariesPeriod;
+    year: number;
 };
 
 export async function buildSpreadSheet(options: SpreadSheetOptions) {
-    const { indicatorReport, countryName } = options;
+    const { indicatorReport, countryName, year } = options;
     const workbook = new ExcelJS.Workbook();
     const sheet = workbook.addWorksheet(i18n.t("Country Projects & Indicators"));
     sheet.columns = generateColumns();
     generateRows(options, sheet);
-    return generateFileInBuffer(workbook, countryName, indicatorReport);
+    return generateFileInBuffer(workbook, countryName, indicatorReport, year);
 }
 
 async function generateFileInBuffer(
     workbook: ExcelJS.Workbook,
     countryName: string,
-    indicatorReport: IndicatorReport
+    indicatorReport: IndicatorReport,
+    year: number
 ) {
     const buffer = await workbook.xlsx.writeBuffer();
-    const filename = `${countryName.toLowerCase()}_${indicatorReport.period.name.toLowerCase()}_report.xlsx`;
+    const filename = `${countryName.toLowerCase()}_${indicatorReport.period.name.toLowerCase()}_${year}_report.xlsx`;
     return { buffer, filename };
 }
 

--- a/src/pages/project-indicators-validation/hooks.ts
+++ b/src/pages/project-indicators-validation/hooks.ts
@@ -15,38 +15,36 @@ export type UseIndicatorValidationProps = {
     indicatorsValidation: IndicatorValidation[];
     onSubmit: (indicatorValidation: IndicatorValidation) => void;
     onUpdateIndicator: (indicator: IndicatorValidation) => void;
+    selectedPeriod: Maybe<UniqueBeneficiariesPeriod>;
 };
 
 export function useIndicatorValidation(props: UseIndicatorValidationProps) {
-    const { indicatorsValidation, onSubmit, onUpdateIndicator, periods } = props;
+    const { indicatorsValidation, onSubmit, onUpdateIndicator, periods, selectedPeriod } = props;
 
-    const [selectedPeriod, setSelectedPeriod] = React.useState<UniqueBeneficiariesPeriod>();
     const [selectedIndicator, setIndicatorValidation] = React.useState<IndicatorValidation>();
     const [dismissNotification, setDismissNotification] = React.useState(false);
     const snackbar = useSnackbar();
     const loadIndicatorValidation = React.useCallback(
-        (period: Maybe<string>) => {
+        (period: string, year: number) => {
             const uniquePeriod = periods.find(item => item.id === period);
             if (!uniquePeriod) {
                 snackbar.error(i18n.t("Period not found"));
                 return;
             }
 
-            const currentIndicatorValidation = indicatorsValidation.find(
-                indicator => indicator.period.id === period
+            const currentIndicatorValidation = indicatorsValidation.find(indicator =>
+                indicator.checkPeriodAndYear(uniquePeriod.id, Number(year))
             );
 
-            setSelectedPeriod(uniquePeriod);
             setDismissNotification(false);
             IndicatorValidation.build({
+                year: Number(year),
                 createdAt: currentIndicatorValidation?.createdAt || "",
                 lastUpdatedAt: currentIndicatorValidation?.lastUpdatedAt,
                 period: uniquePeriod,
                 indicatorsCalculation: currentIndicatorValidation?.indicatorsCalculation || [],
             }).match({
-                success: value => {
-                    setIndicatorValidation(value);
-                },
+                success: setIndicatorValidation,
                 error: err => {
                     const errorMessage = getErrors(err);
                     snackbar.error(errorMessage);

--- a/src/pages/project-wizard/ProjectWizard.tsx
+++ b/src/pages/project-wizard/ProjectWizard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useLocation } from "react-router";
 import _ from "lodash";
-import { Wizard, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { Wizard, useSnackbar, ConfirmationDialog } from "@eyeseetea/d2-ui-components";
 import { LinearProgress } from "@material-ui/core";
 import { Location } from "history";
 
@@ -57,6 +57,7 @@ interface State {
     project: Project | undefined;
     dialogOpen: boolean;
     isUpdated: boolean;
+    showCloneWarning: boolean;
 }
 
 interface Step {
@@ -74,6 +75,7 @@ class ProjectWizardImpl extends React.Component<Props, State> {
         project: undefined,
         dialogOpen: false,
         isUpdated: false,
+        showCloneWarning: true,
     };
 
     async componentDidMount() {
@@ -252,7 +254,7 @@ class ProjectWizardImpl extends React.Component<Props, State> {
     };
 
     render() {
-        const { project, dialogOpen } = this.state;
+        const { project, dialogOpen, showCloneWarning } = this.state;
         const { api, location, action } = this.props;
         if (project) Object.assign(window, { project, Project });
 
@@ -285,6 +287,17 @@ class ProjectWizardImpl extends React.Component<Props, State> {
                     title={`${title}: ${project ? project.name : i18n.t("Loading...")}`}
                     onBackClick={this.cancelSave}
                 />
+
+                <ConfirmationDialog
+                    open={action.type === "clone" && Boolean(project) && showCloneWarning}
+                    title={`${title}: ${project ? project.name : ""}`}
+                    description={i18n.t(
+                        "Please review all prefilled information including Project numbers and dates which MUST be updated."
+                    )}
+                    saveText={i18n.t("OK")}
+                    onSave={() => this.setState({ showCloneWarning: false })}
+                />
+
                 {project ? (
                     <Wizard
                         steps={steps}

--- a/src/pages/project-wizard/ProjectWizard.tsx
+++ b/src/pages/project-wizard/ProjectWizard.tsx
@@ -151,7 +151,7 @@ class ProjectWizardImpl extends React.Component<Props, State> {
             },
             {
                 key: "indicators",
-                label: i18n.t("Selection of Indicators"),
+                label: i18n.t("Indicators"),
                 component: DataElementsSelectionStep,
                 validationKeys: ["dataElementsSelection"],
                 help: helpTexts.indicators,
@@ -167,14 +167,14 @@ class ProjectWizardImpl extends React.Component<Props, State> {
                 : null,
             {
                 key: "mer-indicators",
-                label: i18n.t("Selection of MER Indicators"),
+                label: i18n.t("MER Indicators"),
                 component: MerSelectionStep,
                 validationKeys: ["dataElementsMER"],
                 help: helpTexts.merIndicators,
             },
             {
                 key: "unique-beneficiaries",
-                label: i18n.t("Select of Unique Indicators"),
+                label: i18n.t("Unique Indicators"),
                 component: UniqueIndicatorsStep,
                 validationKeys: ["uniqueIndicators"],
                 help: helpTexts.uniqueIndicators,


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8696nt04q

### :memo: Implementation

- [x] add year selector for indicator validation page
- [x] add year selector in unique beneficiaries report

### :fire: Notes for the reviewer

- Please delete existing data before testing since both indicator validation and unique beneficiaries require the year in dataStore.

Example url  for projects in dataStore `/dhis-web-datastore/index.html#/edit/data-management-app/project-[ID_PROJECT]`. Delete `uniqueBeneficiaries` object.

For unique beneficiaries report:  `/dhis-web-datastore/index.html#/edit/data-management-app/ubreport-[OU_ID]`. Delete the whole key.

### :art: Screenshots

![image](https://github.com/user-attachments/assets/d86391ab-8c3d-42ae-9841-fc0af737322f)

![image](https://github.com/user-attachments/assets/3ae8055e-97a2-44ba-9037-528de6c0853e)


