### PR TITLE
update org. unit levels for countries and projects

### DIFF
--- a/src/components/steps/org-units/OrgUnitsStep.tsx
+++ b/src/components/steps/org-units/OrgUnitsStep.tsx
@@ -5,6 +5,7 @@ import { Title, getValuesFromSelection } from "../utils/common";
 import { MultiSelector } from "@eyeseetea/d2-ui-components";
 import { getProjectFieldName } from "../../../utils/form";
 import { useAppContext } from "../../../contexts/api-context";
+import { baseConfig } from "../../../models/Config";
 
 interface OrganisationUnit {
     id: string;
@@ -75,6 +76,6 @@ const styles = {
     locations: { paddingBottom: 10 },
 };
 
-const selectableLevels = [2];
+const selectableLevels = [baseConfig.orgUnits.levelForCountries];
 
 export default React.memo(OrgUnitsStep);

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -40,8 +40,8 @@ const yes = true as const;
 
 export const baseConfig = {
     orgUnits: {
-        levelForCountries: 2,
-        levelForProjects: 3,
+        levelForCountries: 3,
+        levelForProjects: 4,
     },
     userRoles: {
         feedback: ["DM Feedback"],
@@ -485,7 +485,7 @@ function getFundersAndLocations(metadata: Metadata) {
             id: oug.id,
             displayName: oug.displayName,
             countries: oug.organisationUnits
-                .filter(ou => ou.level === 2)
+                .filter(ou => ou.level === baseConfig.orgUnits.levelForCountries)
                 .map(ou => ({ id: ou.id })),
         }))
         .sortBy(location => location.displayName)

--- a/src/pages/country-indicator-report/CountryIndicatorReport.tsx
+++ b/src/pages/country-indicator-report/CountryIndicatorReport.tsx
@@ -130,7 +130,7 @@ export const CountryIndicatorReport = React.memo(() => {
                     <UserOrgUnits
                         onChange={updateOrgUnit}
                         selected={orgUnit}
-                        selectableLevels={[1, baseConfig.orgUnits.levelForCountries, 3]}
+                        selectableLevels={[1, baseConfig.orgUnits.levelForCountries]}
                         withElevation={false}
                         height={200}
                     />

--- a/src/pages/country-indicator-report/CountryIndicatorReport.tsx
+++ b/src/pages/country-indicator-report/CountryIndicatorReport.tsx
@@ -25,6 +25,7 @@ import { useConfirmChanges } from "../report/MerReport";
 import { UniqueBeneficiariesSettings } from "../../domain/entities/UniqueBeneficiariesSettings";
 import { getYearsFromProject } from "../project-indicators-validation/ProjectIndicatorsValidation";
 import { useProjectStore } from "../../components/app/App";
+import { baseConfig } from "../../models/Config";
 
 export const CountryIndicatorReport = React.memo(() => {
     const titlePage = i18n.t("Country Project & Indicators");
@@ -129,7 +130,7 @@ export const CountryIndicatorReport = React.memo(() => {
                     <UserOrgUnits
                         onChange={updateOrgUnit}
                         selected={orgUnit}
-                        selectableLevels={[1, 2]}
+                        selectableLevels={[1, baseConfig.orgUnits.levelForCountries, 3]}
                         withElevation={false}
                         height={200}
                     />

--- a/src/pages/report/MerReport.tsx
+++ b/src/pages/report/MerReport.tsx
@@ -30,6 +30,7 @@ import { useAppHistory } from "../../utils/use-app-history";
 import { ErrorMessage } from "./ErrorMessage";
 import { useProjectStore } from "../../components/app/App";
 import { AnalyticsInfo } from "../../domain/entities/AnalyticsInfo";
+import { baseConfig } from "../../models/Config";
 
 type ProceedWarning = { type: "hidden" } | { type: "visible"; action: () => void };
 
@@ -269,7 +270,7 @@ function getTranslations() {
     };
 }
 
-const selectableLevels = [2];
+const selectableLevels = [baseConfig.orgUnits.levelForCountries];
 
 const useStyles = makeStyles({
     buttonsWrapper: {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/869cwax7q #869cwax7q

### :memo: Implementation

- [x] update references to new org. unit levels: 
```ts   
orgUnits: {
  levelForCountries: 3,
  levelForProjects: 4,
}
```
- [x] Move `Albania` to new hierarchy "IHQ -> M&E -> Albania" 

### :fire: Notes for the reviewer

We will need to migrate all the projects and countries to the new Org. Unit configuration. I'm not sure if we will do it manually (using the `Hierarchy operations` option in the maitenance app) or we can somehow create an script to do it.

### :art: Screenshots

Only `Albania` was migrated to the new structure that's why you only will see this country in the filter

<img width="1344" height="464" alt="image" src="https://github.com/user-attachments/assets/3d608999-f977-4f82-b84f-71aed73bbe89" />


New project `test_new_ou` created under new structure

<img width="688" height="401" alt="image" src="https://github.com/user-attachments/assets/e57c0a2c-6dc0-4e0b-81f5-0990040487e7" />
