### PR TITLE
Fix country dashboard sharing: restrict access to project users/groups

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-16T13:43:15.193Z\n"
-"PO-Revision-Date: 2026-03-16T13:43:15.193Z\n"
+"POT-Creation-Date: 2026-03-27T15:30:46.362Z\n"
+"PO-Revision-Date: 2026-03-27T15:30:46.362Z\n"
 
 msgid "Validating Project"
 msgstr ""
@@ -594,10 +594,70 @@ msgstr ""
 msgid "Target vs Actual - Benefits"
 msgstr ""
 
+msgid "Target vs Actual - Benefits - Pivot Table"
+msgstr ""
+
+msgid "Target vs Actual - Benefits - Column Chart"
+msgstr ""
+
+msgid "Target vs Actual - People - Column Chart"
+msgstr ""
+
+msgid "MER - Target vs Actual - Benefits - Column Chart"
+msgstr ""
+
+msgid "MER - Target vs Actual - People - Column Chart"
+msgstr ""
+
+msgid "Target vs Actual - Benefits - Column Chart Disaggregated By Indicator"
+msgstr ""
+
+msgid "Target vs Actual - People - Column Chart Disaggregated By Indicator"
+msgstr ""
+
+msgid "Target vs Actual - Benefits - Line Chart"
+msgstr ""
+
+msgid "Target vs Actual - People - Line Chart"
+msgstr ""
+
+msgid "Target vs Actual - People - Line Chart - Male Only"
+msgstr ""
+
+msgid "Target vs Actual - People - Line Chart - Female Only"
+msgstr ""
+
+msgid "Target vs Actual - People - Line/Column Chart - Male Only"
+msgstr ""
+
+msgid "Target vs Actual - People - Line/Column Chart - Female Only"
+msgstr ""
+
 msgid "Target vs Actual - Benefits (Disaggregated)"
 msgstr ""
 
 msgid "Target vs Actual - People"
+msgstr ""
+
+msgid "Target vs Actual - People - Pivot Table"
+msgstr ""
+
+msgid "Target vs Actual - People - Month by Month"
+msgstr ""
+
+msgid "Target vs Actual - Benefits - Month by Month"
+msgstr ""
+
+msgid "Target vs Actual - People - Male Only - Pivot Table"
+msgstr ""
+
+msgid "Target vs Actual - People - Female Only - Pivot Table"
+msgstr ""
+
+msgid "Target vs Actual - People - Male Only - Column Chart"
+msgstr ""
+
+msgid "Target vs Actual - People - Female Only - Column Chart"
 msgstr ""
 
 msgid "Target vs Actual - Unique People"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -609,7 +609,7 @@ msgstr ""
 msgid "Achieved (%) - Benefits"
 msgstr ""
 
-msgid "Achieved (%) - People"
+msgid "Achieved to date (%) - People"
 msgstr ""
 
 msgid "Achieved total to date (%) - People"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-27T15:30:46.362Z\n"
-"PO-Revision-Date: 2026-03-27T15:30:46.362Z\n"
+"POT-Creation-Date: 2026-04-15T02:18:47.807Z\n"
+"PO-Revision-Date: 2026-04-15T02:18:47.807Z\n"
 
 msgid "Validating Project"
 msgstr ""
@@ -1055,6 +1055,9 @@ msgid "List of users"
 msgstr ""
 
 msgid "Message"
+msgstr ""
+
+msgid "Error generating custom form"
 msgstr ""
 
 msgid "Set Target Values for Project"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     collectCoverageFrom: ["src/**/*.js"],
     testPathIgnorePatterns: ["/node_modules/", "/cypress"],
-    transformIgnorePatterns: ["/node_modules/(?!@eyeseetea/d2-ui-components)"],
+    transformIgnorePatterns: ["node_modules/(?!@eyeseetea/d2-ui-components|@eyeseetea/d2-api|axios)"],
     modulePaths: ["src"],
     moduleDirectories: ["node_modules"],
     moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@dhis2/d2-ui-forms": "^6.5.3",
         "@dhis2/ui": "6.12.0",
         "@dhis2/ui-core": "^4.8.0",
-        "@eyeseetea/d2-api": "1.16.0-beta.13",
+        "@eyeseetea/d2-api": "1.21.0-beta.5",
         "@eyeseetea/d2-ui-components": "2.7.0",
         "@eyeseetea/feedback-component": "0.1.2",
         "@krakenjs/post-robot": "^11.0.0",

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -113,6 +113,8 @@ const App: React.FC<AppProps> = props => {
         return <div>Cannot load app: {loadError}</div>;
     }
 
+    const shouldRenderHeaderBar = window.self === window.top;
+
     if (error) {
         return (
             <h3 style={{ margin: 20 }}>
@@ -147,9 +149,11 @@ const App: React.FC<AppProps> = props => {
                                     title={disableLogoNav?.title}
                                     description={disableLogoNav?.description}
                                 />
-                                <div onClick={headerClick}>
-                                    <HeaderBar appName={"Data Management"} />
-                                </div>
+                                {shouldRenderHeaderBar && (
+                                    <div onClick={headerClick}>
+                                        <HeaderBar appName={"Data Management"} />
+                                    </div>
+                                )}
 
                                 <div id="app" className="content">
                                     <ApiContext.Provider value={appContext}>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -35,8 +35,8 @@ const Dashboard: React.FC<DashboardProps> = props => {
     const [state, setState] = React.useState<State>({ type: "loading", height: 10000 });
     const iframeRef: React.RefObject<HTMLIFrameElement> = React.createRef();
 
-    const dashboardUrlBase = `${baseUrl}/dhis-web-dashboard`;
-    const dashboardUrl = dashboardUrlBase + `/#/${id}`;
+    const dashboardUrlBase = `${baseUrl}/apps/dashboard`;
+    const dashboardUrl = dashboardUrlBase + `#/${id}`;
     const translations = getTranslations(name);
     const appHistory = useAppHistory(backUrl);
 
@@ -153,30 +153,11 @@ function waitforElementToLoad(iframeDocument: HTMLDocument, selector: string) {
 async function setDashboardStyling(iframe: HTMLIFrameElement) {
     if (!iframe.contentWindow) return;
     const iframeDocument = iframe.contentWindow.document;
-
-    await waitforElementToLoad(iframeDocument, ".app-wrapper,.dashboard-scroll-container");
-    const iFrameRoot = iframeDocument.querySelector<HTMLElement>("#root");
-    const iFrameWrapper = iframeDocument.querySelector<HTMLElement>(".app-wrapper");
-    const pageContainer = iframeDocument.querySelector<HTMLElement>(".page-container-top-margin");
-
-    if (iFrameWrapper?.children[0])
-        (iFrameWrapper.children[0] as HTMLElement).style.display = "none";
-    if (iFrameWrapper?.children[1])
-        (iFrameWrapper.children[1] as HTMLElement).style.display = "none";
-
-    // 2.36
-    iframeDocument.querySelectorAll("header").forEach(el => el.remove());
-    iframeDocument.querySelectorAll("[data-test='dashboards-bar']").forEach(el => el.remove());
-
-    // Hide top bar actions
-    iframeDocument
-        .querySelectorAll<HTMLElement>(
-            ".dashboard-scroll-container > div > div[class*='ViewTitleBar_container']"
-        )
-        .forEach(el => (el.style.display = "none"));
-
-    if (pageContainer) pageContainer.style.marginTop = "0px";
-    if (iFrameRoot) iFrameRoot.style.marginTop = "0px";
+    await waitforElementToLoad(iframeDocument, "header");
+    const iFrameHeader = iframeDocument.querySelector<HTMLElement>("header");
+    if (iFrameHeader) {
+        iFrameHeader.style.display = "none";
+    }
 }
 
 export default React.memo(Dashboard);

--- a/src/components/data-entry/DataEntry.tsx
+++ b/src/components/data-entry/DataEntry.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import moment from "moment";
-import _ from "lodash";
 import Spinner from "../spinner/Spinner";
 import Dropdown from "../../components/dropdown/Dropdown";
 import Project, { DataSet, monthFormat, getPeriodsData, DataSetType } from "../../models/Project";
@@ -69,7 +68,90 @@ const DataEntry = (props: DataEntryProps) => {
     const [disableValidation, setDisableValidation] = React.useState(false);
     const { periodIds, currentPeriodId } = React.useMemo(() => getPeriodsData(dataSet), [dataSet]);
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
+    const [pluginIframe, setPluginIframe] = React.useState<HTMLIFrameElement | null>(null);
     const categoryId = config.categories.targetActual.id;
+
+    React.useEffect(() => {
+        const outer = iframeRef.current;
+        if (!outer) return;
+
+        const observers: MutationObserver[] = [];
+        const loadListeners: Array<{ el: HTMLIFrameElement; fn: () => void }> = [];
+        const tracked = new WeakSet<HTMLIFrameElement>();
+        let cancelled = false;
+        let found: HTMLIFrameElement | null = null;
+
+        const isLegacyCustomFormPlugin = (ifr: HTMLIFrameElement) => {
+            const doc = ifr.contentDocument;
+            if (!doc) return false;
+            return Boolean(doc.querySelector(".plugin-legacy-custom-forms-wrapper"));
+        };
+
+        const setFound = (ifr: HTMLIFrameElement) => {
+            if (found === ifr) return;
+            found = ifr;
+            console.debug("[data-entry] legacy custom form plugin iframe found:", ifr);
+            setPluginIframe(ifr);
+        };
+
+        const checkPluginCandidate = (ifr: HTMLIFrameElement) => {
+            if (found || cancelled) return;
+            if (!ifr.src.includes("plugin.html")) return;
+            if (isLegacyCustomFormPlugin(ifr)) setFound(ifr);
+        };
+
+        const trackIframe = (ifr: HTMLIFrameElement) => {
+            if (tracked.has(ifr)) return;
+            tracked.add(ifr);
+
+            const onLoad = () => {
+                checkPluginCandidate(ifr);
+
+                if (ifr.contentDocument) watch(ifr.contentDocument);
+            };
+
+            if (ifr.contentDocument && ifr.contentDocument.location.href !== "about:blank") {
+                onLoad();
+            }
+
+            ifr.addEventListener("load", onLoad);
+            loadListeners.push({ el: ifr, fn: onLoad });
+        };
+
+        const watch = (doc: Document) => {
+            if (cancelled) return;
+
+            doc.querySelectorAll<HTMLIFrameElement>("iframe").forEach(checkPluginCandidate);
+
+            const obs = new MutationObserver(() => {
+                if (cancelled || found) return;
+                doc.querySelectorAll<HTMLIFrameElement>("iframe").forEach(ifr => {
+                    checkPluginCandidate(ifr);
+                    trackIframe(ifr);
+                });
+            });
+            obs.observe(doc, { childList: true, subtree: true });
+            observers.push(obs);
+
+            doc.querySelectorAll<HTMLIFrameElement>("iframe").forEach(trackIframe);
+        };
+
+        const start = () => {
+            const doc = outer.contentDocument;
+            if (doc) watch(doc);
+        };
+
+        outer.addEventListener("load", start);
+        start();
+
+        return () => {
+            cancelled = true;
+            observers.forEach(o => o.disconnect());
+            loadListeners.forEach(({ el, fn }) => el.removeEventListener("load", fn));
+            outer.removeEventListener("load", start);
+            setPluginIframe(null);
+        };
+    }, [iframeKey]);
 
     const categoryOptionId =
         props.dataSetType === "actual"
@@ -150,7 +232,7 @@ const DataEntry = (props: DataEntryProps) => {
         Boolean(isDataSetOpen) && state.dropdownHasValues && Boolean(dataSetInfo?.isOpen);
 
     const validation = useValidation({
-        iframeRef,
+        iframe: pluginIframe,
         project,
         dataSetType,
         period,
@@ -202,7 +284,6 @@ const DataEntry = (props: DataEntryProps) => {
                     onClose={validation.clear}
                 />
             )}
-
             <HeaderLogoBlocker
                 isActive={Boolean(period && dataSetInfo?.isOpen)}
                 onActivated={() => setDisableValidation(true)}
@@ -214,7 +295,6 @@ const DataEntry = (props: DataEntryProps) => {
                     }
                 }}
             />
-
             <div style={styles.selector}>
                 {!state.dropdownHasValues && <Spinner isLoading={state.loading} />}
 
@@ -245,7 +325,6 @@ const DataEntry = (props: DataEntryProps) => {
                     </div>
                 )}
             </div>
-
             <iframe
                 data-cy="data-entry"
                 key={iframeKey.getTime()}
@@ -267,76 +346,6 @@ const styles = {
     buttons: { display: "inline", marginLeft: 20 },
     dropdown: { display: "inline-block" },
 };
-
-function isOptionInSelect(select: HTMLSelectElement, value: string): boolean {
-    return Array.from(select.options)
-        .map(opt => opt.value)
-        .includes(value);
-}
-
-function selectOption(select: HTMLSelectElement, value: string) {
-    console.debug("[data-entry] selectOption", value, select.options);
-    const stubEvent = new Event("stub");
-    select.value = value;
-    if (select.onchange) select.onchange(stubEvent);
-}
-
-/* Globals variables used to interact with the data-entry form */
-interface DataEntryWindow {
-    dhis2: {
-        de: {
-            currentPeriodOffset: number;
-            storageManager: { formExists: (dataSetId: string) => boolean };
-        };
-        util: { on: Function };
-    };
-    displayPeriods: () => void;
-    selection: { select: (orgUnitId: string) => void; isBusy(): boolean };
-}
-
-function setSelectPeriod(
-    iframe: HTMLIFrameElement | null,
-    periodKey: string | undefined,
-    attributes: Attributes
-): boolean {
-    if (!iframe || !iframe.contentWindow) return false;
-
-    const iframeWindow = iframe.contentWindow as Window & DataEntryWindow;
-    const periodSelector =
-        iframeWindow.document.querySelector<HTMLSelectElement>("#selectedPeriodId");
-
-    if (periodSelector && periodKey) {
-        const now = moment();
-        const selectedDate = moment(periodKey, monthFormat);
-        const iframeDocument = iframe.contentWindow.document;
-        iframeWindow.dhis2.de.currentPeriodOffset = selectedDate.year() - now.year();
-        try {
-            iframeWindow.displayPeriods();
-        } catch (err) {
-            console.error("setSelectPeriod", err);
-        }
-
-        if (isOptionInSelect(periodSelector, periodKey)) {
-            selectOption(periodSelector, periodKey);
-
-            _(attributes).each((categoryOptionId, categoryId) => {
-                const selector = iframeDocument.querySelector("#category-" + categoryId);
-                if (!selector) {
-                    console.error(`Cannot find attribute selector with categoryId=${categoryId}`);
-                } else {
-                    selectOption(selector as HTMLSelectElement, categoryOptionId);
-                }
-            });
-
-            return true;
-        } else {
-            console.error("Period is not selectable", periodKey);
-            return false;
-        }
-    } else {
-        return false;
-    }
-}
 
 const validationOptions = { interceptSave: true, getOnSaveEvent: true };
 

--- a/src/components/data-entry/DataEntry.tsx
+++ b/src/components/data-entry/DataEntry.tsx
@@ -28,132 +28,37 @@ interface DataEntryProps {
 
 export type ValidateFn = { execute: () => Promise<boolean> };
 
-function autoResizeIframeByContent(iframe: HTMLIFrameElement) {
-    const resize = () => {
-        if (iframe.contentWindow) {
-            const height = iframe.contentWindow.document.body.scrollHeight;
-            if (height > 0) iframe.height = height.toString();
-        }
-    };
-    window.setInterval(resize, 1000);
-}
+const hideHeaderFooterCss = "header, footer { display: none !important; }";
 
-function on<T extends HTMLElement>(document: Document, selector: string, action: (el: T) => void) {
-    const el = document.querySelector(selector) as T;
-    if (el) action(el);
+function injectHideStyles(doc: Document) {
+    if (doc.querySelector("style[data-dm-hide]")) return;
+    const style = doc.createElement("style");
+    style.setAttribute("data-dm-hide", "true");
+    style.textContent = hideHeaderFooterCss;
+    doc.head.appendChild(style);
 }
 
 function setEntryStyling(iframe: HTMLIFrameElement) {
-    if (!iframe.contentWindow) return;
-    const iframeDocument = iframe.contentWindow.document;
-    autoResizeIframeByContent(iframe);
+    if (!iframe.contentWindow || showControls) return;
 
-    if (showControls) return;
+    const applyAll = () => {
+        const outerDoc = iframe.contentWindow?.document;
+        if (!outerDoc) return;
 
-    on(iframeDocument, "#currentSelection", el => el.remove());
-    on(iframeDocument, "#header", el => el.remove());
-    on(iframeDocument, "html", html => (html.style["overflowY"] = "hidden"));
-    on(iframeDocument, "#leftBar", el => (el.style.display = "none"));
-    on(iframeDocument, "#selectionBox", el => (el.style.display = "none"));
-    on(iframeDocument, "body", el => (el.style.marginTop = "-55px"));
-    on(iframeDocument, "#mainPage", el => (el.style.margin = "65px 10px 10px 10px"));
-    on(iframeDocument, "#completenessDiv", el => el.remove());
-    on(iframeDocument, "#moduleHeader", el => el.remove());
-}
+        injectHideStyles(outerDoc);
 
-export function wait(timeSecs: number) {
-    console.debug(`[data-entry] Wait ${timeSecs} seconds`);
-    return new Promise(resolve => setTimeout(resolve, 1000 * timeSecs));
-}
-
-function waitForOption(el: HTMLSelectElement, predicate: (option: HTMLOptionElement) => boolean) {
-    return new Promise(resolve => {
-        const check = () => {
-            const option = _.find(el.options, predicate);
-            if (option) {
-                resolve(undefined);
-            } else {
-                setTimeout(check, 10);
+        outerDoc.querySelectorAll<HTMLIFrameElement>("iframe").forEach(innerIframe => {
+            if (innerIframe.contentDocument) {
+                injectHideStyles(innerIframe.contentDocument);
             }
-        };
-        check();
-    });
-}
-
-async function setDataset(iframe: HTMLIFrameElement, dataSet: DataSet, onDone: () => void) {
-    const contentWindow = iframe.contentWindow as (Window & DataEntryWindow) | null;
-    if (!contentWindow) return;
-
-    const iframeDocument = contentWindow.document;
-    const dataSetSelector = iframeDocument.querySelector<HTMLSelectElement>("#selectedDataSetId");
-    if (!dataSetSelector) return;
-
-    // Avoid database errors
-    try {
-        await contentWindow.dhis2.de.storageManager.formExists(dataSet.id);
-    } catch (err) {
-        console.log("[data-entry] error", err);
-        setTimeout(() => setDataset(iframe, dataSet, onDone), 500);
-    }
-
-    await waitForOption(
-        dataSetSelector,
-        // data-multiorg is set when the country org unit is still selected
-        option => option.value === dataSet.id && !option.getAttribute("data-multiorg")
-    );
-    await wait(1);
-    selectOption(dataSetSelector, dataSet.id);
-
-    onDone();
-}
-
-const getDataEntryForm = async (
-    iframe: HTMLIFrameElement,
-    project: Project,
-    dataSet: DataSet,
-    orgUnitId: string,
-    onDone: () => void
-) => {
-    const contentWindow = iframe.contentWindow as (Window & DataEntryWindow) | null;
-    const iframeDocument = iframe.contentDocument;
-    const { parentOrgUnit } = project;
-    const iframeSelection = contentWindow ? contentWindow.selection : null;
-    if (!contentWindow || !iframeDocument || !iframeSelection || !parentOrgUnit) return;
-    const parentSelector = `#orgUnit${parentOrgUnit.id} .toggle`;
-    const ouSelector = `#orgUnit${orgUnitId} a`;
-
-    const selectDataSet = async () => {
-        console.debug("[data-entry] Select project orgunit", orgUnitId);
-        const ouLink = iframeDocument.querySelector<HTMLAnchorElement>(ouSelector);
-        if (!ouLink) {
-            console.debug("[data-entry] Project orgunit not found, retry");
-            selectOrgUnitAndOptions();
-        } else {
-            ouLink.click();
-            console.debug("[data-entry] Select options");
-            setDataset(iframe, dataSet, onDone);
-        }
+        });
     };
 
-    const selectOrgUnitAndOptions = async () => {
-        const ouEl = iframeDocument.querySelector(ouSelector);
-        if (ouEl) {
-            setTimeout(selectDataSet, 100);
-        } else {
-            const parentEl = iframeDocument.querySelector<HTMLSpanElement>(parentSelector);
-            if (parentEl) {
-                console.debug("[data-entry] Click country", parentSelector);
-                parentEl.click();
-                setTimeout(selectOrgUnitAndOptions, 100);
-            } else {
-                console.debug("[data-entry] Country orgunit not found, wait");
-                setTimeout(selectOrgUnitAndOptions, 100);
-            }
-        }
-    };
+    applyAll();
+    const intervalId = window.setInterval(applyAll, 500);
 
-    selectOrgUnitAndOptions();
-};
+    return intervalId;
+}
 
 const DataEntry = (props: DataEntryProps) => {
     const { goBack, orgUnitId, dataSet, attributes, dataSetType, onValidateFnChange } = props;
@@ -164,13 +69,21 @@ const DataEntry = (props: DataEntryProps) => {
     const [disableValidation, setDisableValidation] = React.useState(false);
     const { periodIds, currentPeriodId } = React.useMemo(() => getPeriodsData(dataSet), [dataSet]);
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
-    const iFrameSrc = `${baseUrl}/dhis-web-dataentry/index.action`;
+    const categoryId = config.categories.targetActual.id;
+
+    const categoryOptionId =
+        props.dataSetType === "actual"
+            ? config.categoryOptions.actual.id
+            : config.categoryOptions.target.id;
 
     const [state, setState] = useState({
         loading: false,
         dropdownHasValues: false,
         dropdownValue: currentPeriodId,
     });
+
+    const queryParams = `?attributeOptionComboSelection=${categoryId}-${categoryOptionId}&dataSetId=${dataSet.id}&orgUnitId=${orgUnitId}&periodId=${state.dropdownValue}`;
+    const iFrameSrc = `${baseUrl}/apps/aggregate-data-entry#/${queryParams}`;
 
     function reloadIframe() {
         setState(state => ({ ...state, loading: true }));
@@ -180,24 +93,47 @@ const DataEntry = (props: DataEntryProps) => {
 
     useEffect(() => {
         if (state.dropdownValue) {
-            setDataSetOpen(setSelectPeriod(iframeRef.current, state.dropdownValue, attributes));
+            setDataSetOpen(true);
         }
     }, [state, project, iframeKey, attributes]);
 
     useEffect(() => {
         const iframe = iframeRef.current;
+        if (!iframe) return;
 
-        if (iframe) {
-            if (!showControls) iframe.style.display = "none";
-            setState(prevState => ({ ...prevState, loading: true }));
-            iframe.addEventListener("load", () => {
-                setEntryStyling(iframe);
-                getDataEntryForm(iframe, project, dataSet, orgUnitId, () =>
-                    setState(prevState => ({ ...prevState, dropdownHasValues: true }))
-                );
-            });
-        }
+        const controller = new AbortController();
+
+        if (!showControls) iframe.style.display = "none";
+        setState(prevState => ({ ...prevState, loading: true }));
+
+        iframe.addEventListener(
+            "load",
+            () => {
+                setState(prevState => ({ ...prevState, dropdownHasValues: true }));
+            },
+            { signal: controller.signal }
+        );
+
+        return () => controller.abort();
     }, [iframeKey, dataSet, orgUnitId, project]);
+
+    useEffect(() => {
+        const iframe = iframeRef.current;
+        if (!iframe || showControls) return;
+
+        let intervalId: number | undefined;
+
+        const onLoad = () => {
+            intervalId = setEntryStyling(iframe);
+        };
+
+        iframe.addEventListener("load", onLoad);
+
+        return () => {
+            iframe.removeEventListener("load", onLoad);
+            window.clearInterval(intervalId);
+        };
+    }, [iframeKey]);
 
     const period = state.dropdownValue;
 
@@ -324,7 +260,7 @@ const DataEntry = (props: DataEntryProps) => {
 };
 
 const styles = {
-    iframe: { width: "100%", border: 0, overflow: "hidden" },
+    iframe: { width: "100%", border: 0, overflow: "hidden", minHeight: "100vh" },
     iframeHidden: { maxHeight: 0, border: 0 },
     backgroundIframe: { backgroundColor: "white" },
     selector: { padding: "35px  10px 10px 5px", backgroundColor: "white" },

--- a/src/components/data-entry/data-entry-hooks.ts
+++ b/src/components/data-entry/data-entry-hooks.ts
@@ -43,15 +43,14 @@ const inputMsgFromIframeTypes: MsgFromIframe["type"][] = [
 ];
 
 export function useDhis2EntryEvents(
-    iframeRef: React.RefObject<HTMLIFrameElement>,
+    iframe: HTMLIFrameElement | null,
     onMessage: (inputMsg: InputMsg) => Promise<boolean> | undefined,
     options: Options = {},
     iframeKey: object
 ): void {
     const onMessageFromIframe = React.useCallback(
         async ev => {
-            const iwindow =
-                iframeRef.current && (iframeRef.current.contentWindow as DataEntryWindow);
+            const iwindow = iframe && (iframe.contentWindow as DataEntryWindow);
             if (!iwindow) return;
             const { data } = ev;
             if (!isInputMsgFromIframe(data)) return;
@@ -113,11 +112,11 @@ export function useDhis2EntryEvents(
                 }
             }
         },
-        [iframeRef, onMessage]
+        [iframe, onMessage]
     );
 
     React.useEffect(() => {
-        const iwindow = getIframeWindow(iframeRef);
+        const iwindow = getIframeWindow(iframe);
         if (!iwindow || !onMessage) return;
 
         window.addEventListener("message", onMessageFromIframe);
@@ -125,21 +124,26 @@ export function useDhis2EntryEvents(
         return () => {
             window.removeEventListener("message", onMessageFromIframe);
         };
-    }, [iframeRef, onMessage, options, onMessageFromIframe]);
+    }, [iframe, onMessage, options, onMessageFromIframe]);
 
     React.useEffect(() => {
-        const iwindow = getIframeWindow(iframeRef);
+        const iwindow = getIframeWindow(iframe);
         if (!iwindow) return;
 
-        iwindow.addEventListener("load", () => {
+        const inject = () => {
             const init = setupDataEntryInterceptors.toString();
             iwindow.eval(`(${init})(${JSON.stringify(options)});`);
-        });
-    }, [iframeRef, options, iframeKey]);
+        };
+
+        if (iwindow.document?.readyState === "complete") {
+            inject();
+        } else {
+            iwindow.addEventListener("load", inject, { once: true });
+        }
+    }, [iframe, options, iframeKey]);
 }
 
-function getIframeWindow(iframeRef: React.RefObject<HTMLIFrameElement>) {
-    const iframe = iframeRef.current;
+function getIframeWindow(iframe: HTMLIFrameElement | null) {
     return iframe ? (iframe.contentWindow as DataEntryWindow) : undefined;
 }
 
@@ -176,6 +180,25 @@ function setupDataEntryInterceptors(options: Options = {}) {
     console.debug("|data-entry|:setup-interceptors", iframeWindow.dataEntryHooksInit, options);
     if (iframeWindow.dataEntryHooksInit) return;
 
+    const postToAncestors = (msg: unknown) => {
+        const targets: Window[] = [];
+        let prev: Window = iframeWindow;
+        let win: Window | null = iframeWindow.parent;
+        while (win && win !== prev) {
+            targets.push(win);
+            prev = win;
+            win = win.parent;
+        }
+        console.debug("<-|data-entry| posting to", targets.length, "ancestors", msg);
+        targets.forEach(t => {
+            try {
+                t.postMessage(msg, window.location.origin);
+            } catch (e) {
+                console.debug("<-|data-entry| post failed", e);
+            }
+        });
+    };
+
     if (options.getOnSaveEvent) {
         iframeWindow
             .jQuery(iframeWindow)
@@ -186,13 +209,13 @@ function setupDataEntryInterceptors(options: Options = {}) {
                         type: "dataValueSavedFromIframe",
                         dataValue: dataValue,
                     };
-                    console.debug("<-|data-entry|", msg);
-                    iframeWindow.parent.postMessage(msg, window.location.origin);
+                    postToAncestors(msg);
                 }
             );
     }
 
     const saveValOld = iframeWindow.saveVal;
+    console.debug("|data-entry|:saveValOld type:", typeof saveValOld);
 
     if (options.interceptSave) {
         // Wrap saveVal (dhis-web-dataentry/javascript/entry.js)
@@ -208,8 +231,7 @@ function setupDataEntryInterceptors(options: Options = {}) {
                 type: "preSaveDataValueFromIframe",
                 dataValue: preSaveDataValue,
             };
-            console.debug("<-|data-entry|", msg);
-            iframeWindow.parent.postMessage(msg, window.location.origin);
+            postToAncestors(msg);
         };
     }
 

--- a/src/components/data-entry/validation-hooks.ts
+++ b/src/components/data-entry/validation-hooks.ts
@@ -117,7 +117,9 @@ export function useValidation(hookOptions: {
 
     usePageExitConfirmation(showPromptFn, disableValidation);
 
-    useDhis2EntryEvents(iframeRef, onMessage, options, iframeKey);
+    // TODO: new data entry app does not expose any global event
+    // so we cannot apply this hook
+    // useDhis2EntryEvents(iframeRef, onMessage, options, iframeKey);
 
     return { result: validationResult, clear: clearResult, validate: validate };
 }

--- a/src/components/data-entry/validation-hooks.ts
+++ b/src/components/data-entry/validation-hooks.ts
@@ -21,7 +21,7 @@ export interface UseValidationResponse {
 }
 
 export function useValidation(hookOptions: {
-    iframeRef: React.RefObject<HTMLIFrameElement>;
+    iframe: HTMLIFrameElement | null;
     project: Project;
     dataSetType: DataSetType;
     period: Maybe<string>;
@@ -31,7 +31,7 @@ export function useValidation(hookOptions: {
     disableValidation: boolean;
 }): UseValidationResponse {
     const {
-        iframeRef,
+        iframe,
         project,
         dataSetType,
         period,
@@ -117,9 +117,7 @@ export function useValidation(hookOptions: {
 
     usePageExitConfirmation(showPromptFn, disableValidation);
 
-    // TODO: new data entry app does not expose any global event
-    // so we cannot apply this hook
-    // useDhis2EntryEvents(iframeRef, onMessage, options, iframeKey);
+    useDhis2EntryEvents(iframe, onMessage, options, iframeKey);
 
     return { result: validationResult, clear: clearResult, validate: validate };
 }

--- a/src/components/steps/sharing/SharingStep.tsx
+++ b/src/components/steps/sharing/SharingStep.tsx
@@ -65,7 +65,16 @@ const SharingStep: React.FC<StepProps> = props => {
     return (
         <div data-cy="sharing">
             <Sharing
-                meta={sharedObject}
+                meta={{
+                    meta: sharedObject.meta,
+                    object: {
+                        id: sharedObject.object.id,
+                        publicAccess: sharedObject.object.sharing.public,
+                        externalAccess: sharedObject.object.sharing.external,
+                        userAccesses: Object.values(sharedObject.object.sharing.users),
+                        userGroupAccesses: Object.values(sharedObject.object.sharing.userGroups),
+                    },
+                }}
                 showOptions={showOptions}
                 onSearch={search}
                 onChange={setProjectSharing}

--- a/src/data/DataSetCustomForm.ts
+++ b/src/data/DataSetCustomForm.ts
@@ -1,0 +1,319 @@
+import Project, { DataSetType } from "../models/Project";
+import { D2Api, Id } from "../types/d2-api";
+import { getUid } from "../utils/dhis2";
+
+type CategoryOption = { id: Id; name: string };
+type Category = { id: Id; name: string; categoryOptions: CategoryOption[] };
+type CategoryOptionCombo = { id: Id; name: string; categoryOptions: { id: Id }[] };
+type CategoryCombo = {
+    id: Id;
+    name: string;
+    categories: Category[];
+    categoryOptionCombos: CategoryOptionCombo[];
+};
+type DataElement = {
+    id: Id;
+    name: string;
+    formName?: string;
+    categoryCombo: CategoryCombo;
+};
+type Section = { id: Id; name: string; dataElements: DataElement[] };
+type DataSet = { id: Id; name: string; sections: Section[] };
+
+type Group = { categoryCombo: CategoryCombo; elements: DataElement[] };
+
+export class DataSetCustomForm {
+    constructor(private api: D2Api) {}
+
+    async generate(dataSetId: Id): Promise<string> {
+        const dataSet = await this.fetchDataSet(dataSetId);
+        if (!dataSet) return "";
+        return this.buildHtml(dataSet);
+    }
+
+    async saveCustomForm(
+        dataSetId: Id,
+        project: Project,
+        dataSetType: DataSetType
+    ): Promise<Id | undefined> {
+        const dataEntryForm = await this.generate(dataSetId);
+        if (!dataEntryForm) return undefined;
+
+        const customFormId = getUid("dataEntryForm", dataSetId);
+        const labelType = dataSetType === "actual" ? "Actual" : "Target";
+
+        const dataSetMetadata = await this.api.models.dataSets
+            .getById(dataSetId, { fields: { $owner: true } })
+            .getData();
+
+        const metadata = {
+            dataEntryForms: [
+                {
+                    id: customFormId,
+                    name: `${project.name} ${labelType}`,
+                    style: "NORMAL" as const,
+                    htmlCode: dataEntryForm,
+                },
+            ],
+            dataSets: [{ ...dataSetMetadata, dataEntryForm: { id: customFormId } }],
+        };
+
+        await this.api.metadata.post(metadata).getData();
+
+        return customFormId;
+    }
+
+    private async fetchDataSet(id: Id): Promise<DataSet | undefined> {
+        const res = await this.api.metadata
+            .get({
+                dataSets: {
+                    fields: {
+                        id: true,
+                        name: true,
+                        sections: {
+                            id: true,
+                            name: true,
+                            dataElements: {
+                                id: true,
+                                name: true,
+                                formName: true,
+                                categoryCombo: {
+                                    id: true,
+                                    name: true,
+                                    categories: {
+                                        id: true,
+                                        name: true,
+                                        categoryOptions: { id: true, name: true },
+                                    },
+                                    categoryOptionCombos: {
+                                        id: true,
+                                        name: true,
+                                        categoryOptions: { id: true },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    filter: { id: { eq: id } },
+                },
+            })
+            .getData()
+            .catch(() => undefined);
+        const ds = res?.dataSets[0];
+        if (!ds) return undefined;
+        return ds as unknown as DataSet;
+    }
+
+    private buildHtml(ds: DataSet): string {
+        const sections = ds.sections;
+        const tabs = sections
+            .map(
+                (s, i) =>
+                    `<button type="button" class="cf-tab${
+                        i === 0 ? " selected" : ""
+                    }" data-section="${s.id}">${escapeHtml(s.name)}</button>`
+            )
+            .join("");
+        const panels = sections.map((s, i) => this.renderSection(s, i === 0)).join("");
+        return [
+            `<style>${this.styles()}</style>`,
+            `<div class="cf-wrapper">`,
+            `  <div class="cf-tabs">${tabs}</div>`,
+            `  <div class="cf-panels">${panels}</div>`,
+            `</div>`,
+            `<script>${this.script()}</script>`,
+        ].join("\n");
+    }
+
+    private renderSection(section: Section, active: boolean): string {
+        const groups = groupByCategoryCombo(section.dataElements);
+        const tbodies = groups.map(g => this.renderGroup(g)).join("");
+        return `<div class="cf-panel${active ? " active" : ""}" data-section="${section.id}">
+  <table class="cf-table">
+    <thead>
+      <tr><th colspan="100%" class="cf-section-header">${escapeHtml(section.name)}</th></tr>
+      <tr><th colspan="100%" class="cf-filter-cell"><input type="text" class="cf-filter" placeholder="Type here to filter rows in this section"/></th></tr>
+    </thead>
+    ${tbodies}
+  </table>
+</div>`;
+    }
+
+    private renderGroup(group: Group): string {
+        const { categoryCombo: cc, elements } = group;
+        const isDefault = cc.name === "default";
+        if (isDefault) {
+            const coc = cc.categoryOptionCombos[0];
+            const rows = elements
+                .map(
+                    de =>
+                        `<tr class="cf-data-row"><td class="cf-de-name">${escapeHtml(
+                            formNameOf(de)
+                        )}</td><td class="cf-cell"><input id="${de.id}-${
+                            coc.id
+                        }-val" name="entryfield" title="${escapeHtml(de.name)}"/></td></tr>`
+                )
+                .join("");
+            return `<tbody class="cf-group">
+  <tr><th class="cf-cat-corner"></th><th class="cf-cat-header">Value</th></tr>
+  ${rows}
+</tbody>`;
+        }
+        const cats = cc.categories;
+        const headerRows = this.renderCategoryHeaders(cats);
+        const colCocs = this.orderedCocs(cc);
+        const rows = elements
+            .map(de => {
+                const cells = colCocs
+                    .map(
+                        coc =>
+                            `<td class="cf-cell"><input id="${de.id}-${
+                                coc.id
+                            }-val" name="entryfield" title="${escapeHtml(de.name)}"/></td>`
+                    )
+                    .join("");
+                return `<tr class="cf-data-row"><td class="cf-de-name">${escapeHtml(
+                    formNameOf(de)
+                )}</td>${cells}</tr>`;
+            })
+            .join("");
+        return `<tbody class="cf-group">
+  ${headerRows}
+  ${rows}
+</tbody>`;
+    }
+
+    private renderCategoryHeaders(cats: Category[]): string {
+        const counts = cats.map(c => c.categoryOptions.length);
+        return cats
+            .map((cat, i) => {
+                const colspan = counts.slice(i + 1).reduce((a, b) => a * b, 1);
+                const repeats = counts.slice(0, i).reduce((a, b) => a * b, 1);
+                const cells: string[] = [];
+                for (let r = 0; r < repeats; r++) {
+                    for (const opt of cat.categoryOptions) {
+                        cells.push(
+                            `<th class="cf-cat-header" colspan="${colspan}">${escapeHtml(
+                                opt.name
+                            )}</th>`
+                        );
+                    }
+                }
+                return `<tr><th class="cf-cat-name">${escapeHtml(cat.name)}</th>${cells.join(
+                    ""
+                )}</tr>`;
+            })
+            .join("");
+    }
+
+    private orderedCocs(cc: CategoryCombo): CategoryOptionCombo[] {
+        const cartesian = cc.categories.reduce<string[][]>(
+            (acc, cat) => acc.flatMap(prev => cat.categoryOptions.map(opt => [...prev, opt.id])),
+            [[]]
+        );
+        const cocByKey = new Map<string, CategoryOptionCombo>();
+        for (const coc of cc.categoryOptionCombos) {
+            const key = coc.categoryOptions
+                .map(o => o.id)
+                .sort()
+                .join(",");
+            cocByKey.set(key, coc);
+        }
+        return cartesian.map(ids => {
+            const key = [...ids].sort().join(",");
+            const coc = cocByKey.get(key);
+            if (!coc)
+                throw new Error(
+                    `CategoryOptionCombo not found in categoryCombo ${cc.id} for options: ${key}`
+                );
+            return coc;
+        });
+    }
+
+    private styles(): string {
+        return `
+.cf-wrapper, .cf-wrapper * { font-family: Roboto, sans-serif; box-sizing: border-box; }
+.cf-wrapper { color: #212934; }
+.cf-tabs { display: flex; border-bottom: 1px solid #d5dae0; margin-bottom: 8px; flex-wrap: wrap; }
+.cf-tabs .cf-tab { background: none; border: none; padding: 12px 16px; cursor: pointer; font-size: 14px; color: #4a5768; border-bottom: 3px solid transparent; font-family: Roboto, sans-serif; }
+.cf-tabs .cf-tab.selected { color: #2c6693; border-bottom-color: #2c6693; font-weight: 500; }
+.cf-panel { display: none; }
+.cf-panel.active { display: block; }
+.cf-table { min-width: 100%; border-collapse: collapse; table-layout: fixed; }
+.cf-section-header { background-color: #404b5a; color: #fff; text-align: left; padding: 10px 14px; font-weight: 500; font-size: 14px; }
+.cf-filter-cell { padding: 8px; background: #fff; border: 1px solid #e8edf2; }
+.cf-filter { width: 100%; padding: 6px 10px; border: 1px solid #d5dae0; border-radius: 3px; font-size: 13px; font-family: Roboto, sans-serif; }
+.cf-cat-header, .cf-cat-name, .cf-cat-corner { background-color: #f3f5f7; color: #000; font-weight: 500; padding: 8px 10px; border: 1px solid #e8edf2; font-size: 13px; }
+.cf-cat-header { text-align: center; }
+.cf-cat-name { text-align: left; }
+.cf-de-name { background-color: #fff; padding: 8px 10px; border: 1px solid #e8edf2; font-size: 13px; }
+.cf-cell { background-color: #fff; padding: 0; border: 1px solid #e8edf2; }
+.cf-cell .field-wrapper { display: block !important; width: 100%; }
+.cf-cell input { width: 100%; box-sizing: border-box; border: none; padding: 8px 10px; font-size: 13px; text-align: right; outline: none; background: transparent; font-family: Roboto, sans-serif; }
+.cf-cell input:focus { background: #e8f0fa; }
+`;
+    }
+
+    private script(): string {
+        return `
+(function() {
+  document.querySelectorAll('.cf-wrapper').forEach(function(wrapper) {
+    var tabs = wrapper.querySelectorAll('.cf-tab');
+    var panels = wrapper.querySelectorAll('.cf-panel');
+    tabs.forEach(function(tab) {
+      tab.addEventListener('click', function() {
+        var id = tab.getAttribute('data-section');
+        tabs.forEach(function(t) { t.classList.remove('selected'); });
+        tab.classList.add('selected');
+        panels.forEach(function(p) {
+          p.classList.toggle('active', p.getAttribute('data-section') === id);
+        });
+      });
+    });
+    wrapper.querySelectorAll('.cf-filter').forEach(function(input) {
+      input.addEventListener('input', function() {
+        var term = input.value.toLowerCase();
+        var panel = input.closest('.cf-panel');
+        if (!panel) return;
+        panel.querySelectorAll('tr.cf-data-row').forEach(function(row) {
+          var nameCell = row.querySelector('.cf-de-name');
+          if (!nameCell) return;
+          var match = nameCell.textContent.toLowerCase().indexOf(term) !== -1;
+          row.style.display = match ? '' : 'none';
+        });
+      });
+    });
+  });
+})();
+`;
+    }
+}
+
+function formNameOf(de: DataElement): string {
+    return de.formName || de.name;
+}
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function groupByCategoryCombo(des: DataElement[]): Group[] {
+    const groups: Group[] = [];
+    const idx = new Map<Id, number>();
+    for (const de of des) {
+        const ccId = de.categoryCombo.id;
+        const at = idx.get(ccId);
+        if (at !== undefined) {
+            groups[at].elements.push(de);
+        } else {
+            idx.set(ccId, groups.length);
+            groups.push({ categoryCombo: de.categoryCombo, elements: [de] });
+        }
+    }
+    return groups;
+}

--- a/src/migrations/tasks/03.add-role-mer-approver.ts
+++ b/src/migrations/tasks/03.add-role-mer-approver.ts
@@ -1,4 +1,4 @@
-import { D2Api, D2UserAuthorityGroup } from "../../types/d2-api";
+import { D2Api, D2UserRole } from "../../types/d2-api";
 import { Debug, Migration } from "../types";
 import { getUid } from "../../utils/dhis2";
 import { post } from "./common";
@@ -11,7 +11,7 @@ class AddRoleMerApproverMigration {
     }
 
     async createUserRole() {
-        const role: Partial<D2UserAuthorityGroup> = {
+        const role: Partial<D2UserRole> = {
             id: getUid("userRole", "mer-approver"),
             name: "MER Approver",
             authorities: [

--- a/src/migrations/tasks/10.fix-country-dashboard-sharing.ts
+++ b/src/migrations/tasks/10.fix-country-dashboard-sharing.ts
@@ -1,0 +1,28 @@
+import { Config } from "./../../models/Config";
+import { D2Api, Id } from "../../types/d2-api";
+import { Debug, Migration } from "../types";
+import Project from "../../models/Project";
+import { promiseMap, enumerate } from "../utils";
+import { getConfig } from "../../models/Config";
+import ProjectDashboardSave from "../../models/ProjectDashboardSave";
+import { getProjectIds } from "./common";
+
+async function migrate(api: D2Api, debug: Debug): Promise<void> {
+    const config = await getConfig(api);
+    const projectIds = await getProjectIds(api, config, debug);
+    debug(`Projects count: ${projectIds.length}`);
+    await saveProjectDashboards(api, config, debug, projectIds);
+}
+
+async function saveProjectDashboards(api: D2Api, config: Config, debug: Debug, projectIds: Id[]) {
+    return promiseMap(enumerate(projectIds), async ([idx, projectId]) => {
+        const project = await Project.get(api, config, projectId);
+        const name = `[${project.parentOrgUnit?.displayName}] ${project.name} (${project.id})`;
+        debug(`Save dashboard (${idx + 1} / ${projectIds.length}): ${name}`);
+        await new ProjectDashboardSave(project).execute();
+    });
+}
+
+const migration: Migration = { name: "Fix country dashboard sharing", migrate };
+
+export default migration;

--- a/src/migrations/tasks/index.ts
+++ b/src/migrations/tasks/index.ts
@@ -11,5 +11,6 @@ export async function getMigrationTasks(): Promise<MigrationTasks> {
         migration(7, (await import("./07.update-to-v2.36")).default),
         migration(8, (await import("./08.set-integer-people-dataelements")).default),
         migration(9, (await import("./09.add-last-updated-data")).default),
+        migration(10, (await import("./10.fix-country-dashboard-sharing")).default),
     ];
 }

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -320,7 +320,7 @@ class ConfigLoader {
         const metadata: Metadata = await this.api.metadata.get(metadataParams).getData();
         const d2CurrentUser = await this.getCurrentUser();
         const { funders, locations } = getFundersAndLocations(metadata);
-        const { userRoles, username } = d2CurrentUser.userCredentials;
+        const { userRoles, username } = d2CurrentUser;
         const currentUser: Config["currentUser"] = { ...d2CurrentUser, userRoles, username };
         const dataElementsMetadata = await this.getDataElementsMetadata(currentUser, metadata);
         const categoryCombos = indexObjects(metadata, "categoryCombos");
@@ -370,7 +370,8 @@ class ConfigLoader {
                 fields: {
                     id: true,
                     displayName: true,
-                    userCredentials: { username: true, userRoles: { name: true } },
+                    username: true,
+                    userRoles: { name: true },
                     organisationUnits: { id: true, displayName: true, level: true },
                     authorities: true,
                 },

--- a/src/models/CountryDashboard.ts
+++ b/src/models/CountryDashboard.ts
@@ -33,7 +33,7 @@ import {
     Condition,
     DashboardSourceMetadata,
 } from "./ProjectsListDashboard";
-import { D2Sharing, getD2Access } from "./Sharing";
+import { D2Sharing, getD2SharingMap, fullMetadataAccess } from "./Sharing";
 
 type D2VisualizationPayload = PartialPersistedModel<D2Visualization>;
 
@@ -241,9 +241,14 @@ export default class CountryDashboard {
         return d2Table ? { ...d2Table, ...chart.extra } : null;
     }
 
-    getSharing(): Partial<D2Sharing> {
+    getSharing(): D2Sharing {
+        const { userAccesses, userGroupAccesses } = this.country.projectsListDashboard.sharing;
+
         return {
-            public: getD2Access({ meta: { read: true, write: true } }),
+            public: "--------",
+            external: false,
+            users: getD2SharingMap(userAccesses, fullMetadataAccess),
+            userGroups: getD2SharingMap(userGroupAccesses, fullMetadataAccess),
         };
     }
 }

--- a/src/models/CountryDashboard.ts
+++ b/src/models/CountryDashboard.ts
@@ -125,7 +125,7 @@ export default class CountryDashboard {
             id: getUid("country-dashboard", country.id),
             name: country.name,
             dashboardItems: positionItems(items, positionItemsOptions),
-            ...this.getSharing(),
+            sharing: this.getSharing(),
         };
 
         const countryUpdated = addAttributeValueToObj(d2Country, {
@@ -243,7 +243,7 @@ export default class CountryDashboard {
 
     getSharing(): Partial<D2Sharing> {
         return {
-            publicAccess: getD2Access({ meta: { read: true, write: true } }),
+            public: getD2Access({ meta: { read: true, write: true } }),
         };
     }
 }

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -29,6 +29,9 @@ interface Item {
 
 export interface VisualizationDefinition {
     type: "chart" | "table";
+    // TODO: validate if having undefined for the other visualizations
+    // modify somehow the functionality
+    chartType?: Exclude<D2Visualization["type"], "PIVOT_TABLE">;
     key: string;
     name: string;
     items: Item[];
@@ -84,7 +87,7 @@ export function getD2Visualization(visualization: Visualization): MaybeD2Visuali
 
     const d2Table: PartialPersistedModel<D2Visualization> = {
         id: getUid(visualization.key, ""),
-        type: visualization.type === "table" ? "PIVOT_TABLE" : "COLUMN",
+        type: visualization.type === "table" ? "PIVOT_TABLE" : visualization.chartType || "COLUMN",
         name: visualization.name,
         numberType: "VALUE",
         legendDisplayStyle: "FILL",

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -30,8 +30,6 @@ interface Item {
 
 export interface VisualizationDefinition {
     type: "chart" | "table";
-    // TODO: validate if having undefined for the other visualizations
-    // modify somehow the functionality
     chartType?: Exclude<D2Visualization["type"], "PIVOT_TABLE">;
     periodStrategy?: PeriodStrategy;
     key: string;

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -90,12 +90,11 @@ export function getD2Visualization(visualization: Visualization): MaybeD2Visuali
         type: visualization.type === "table" ? "PIVOT_TABLE" : visualization.chartType || "COLUMN",
         name: visualization.name,
         numberType: "VALUE",
-        legendDisplayStyle: "FILL",
         rowSubTotals: true,
         showDimensionLabels: true,
         showData: true,
         aggregationType: "DEFAULT",
-        legendDisplayStrategy: "FIXED",
+        legend: { strategy: "FIXED", style: "FILL", showKey: false },
         rowTotals: visualization.rowTotals ?? true,
         digitGroupSeparator: "SPACE",
         dataDimensionItems,
@@ -109,7 +108,7 @@ export function getD2Visualization(visualization: Visualization): MaybeD2Visuali
         rows: visualization.rows,
         rowDimensions: visualization.rows.map(dimension => dimension.id),
         categoryDimensions: getCategoryDimensions(categoryDimensions),
-        ...visualization.sharing,
+        sharing: visualization.sharing,
     };
 
     return _.merge({}, d2Table, visualization.extra || {});
@@ -135,7 +134,7 @@ export function getReportTableItem(
     if (!reportTable) return null;
     return {
         id: getUid("dashboardItem", reportTable.id),
-        type: "REPORT_TABLE" as const,
+        type: "VISUALIZATION" as const,
         visualization: { id: reportTable.id },
         ...(dashboardItemAttributes || {}),
     };
@@ -148,7 +147,7 @@ export function getChartDashboardItem(
     if (!chart) return null;
     return {
         id: getUid("dashboardItem", chart.id),
-        type: "CHART" as const,
+        type: "VISUALIZATION" as const,
         visualization: { id: chart.id },
         ...(dashboardItemAttributes || {}),
     };

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -10,6 +10,7 @@ import {
 import { Maybe } from "../types/utils";
 import { getUid, getRefs } from "../utils/dhis2";
 import { D2Sharing } from "./Sharing";
+import { PeriodStrategy } from "./Period";
 
 export const dimensions = {
     period: { id: "pe" },
@@ -32,6 +33,7 @@ export interface VisualizationDefinition {
     // TODO: validate if having undefined for the other visualizations
     // modify somehow the functionality
     chartType?: Exclude<D2Visualization["type"], "PIVOT_TABLE">;
+    periodStrategy?: PeriodStrategy;
     key: string;
     name: string;
     items: Item[];

--- a/src/models/Period.ts
+++ b/src/models/Period.ts
@@ -1,10 +1,13 @@
 import moment from "moment";
+import _ from "lodash";
 import { Maybe } from "../types/utils";
 import { getMonthsRange } from "../utils/date";
 
 export type Period = string;
+export type PeriodStrategy = "monthly" | "yearly" | "monthly_interleaved_by_month";
 
 export const monthPeriod = "YYYYMM";
+export const yearPeriod = "YYYY";
 
 export function getPeriodsFromRange(start: Maybe<Date>, end: Maybe<Date>): Period[] {
     if (!start || !end) return [];
@@ -15,4 +18,33 @@ export function getPeriodsFromRange(start: Maybe<Date>, end: Maybe<Date>): Perio
 export function filterPeriods(periods: Period[], options: { toDate?: boolean } = {}): Period[] {
     const now = moment();
     return !options.toDate ? periods : periods.filter(period => moment(period, monthPeriod) <= now);
+}
+
+export function getVisualizationPeriods(
+    periods: Period[],
+    options: { toDate?: boolean; periodStrategy?: PeriodStrategy } = {}
+): Period[] {
+    const { toDate, periodStrategy = "monthly" } = options;
+
+    const transformedPeriods =
+        periodStrategy === "yearly"
+            ? _.uniq(periods.map(period => moment(period, monthPeriod).format(yearPeriod))).sort()
+            : periodStrategy === "monthly_interleaved_by_month"
+            ? _(periods)
+                  .groupBy(period => moment(period, monthPeriod).format("MM"))
+                  .toPairs()
+                  .sortBy(([month]) => month)
+                  .flatMap(([_month, monthPeriods]) => _.sortBy(monthPeriods))
+                  .value()
+            : periods;
+
+    if (!toDate) return transformedPeriods;
+
+    const now = moment();
+
+    return transformedPeriods.filter(period =>
+        periodStrategy === "yearly"
+            ? moment(period, yearPeriod).year() <= now.year()
+            : moment(period, monthPeriod) <= now
+    );
 }

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -4,14 +4,13 @@ import _ from "lodash";
 import { D2Api, Id, Ref } from "../types/d2-api";
 // @ts-ignore
 import { generateUid } from "d2/uid";
-import { TableSorting } from "@eyeseetea/d2-ui-components";
 
 import i18n from "../locales";
 import DataElementsSet, { PeopleOrBenefit, DataElement, SelectionInfo } from "./dataElementsSet";
 import ProjectDb from "./ProjectDb";
 import { toISOString, getMonthsRange } from "../utils/date";
 import ProjectDownload from "./ProjectDownload";
-import ProjectList, { ProjectForList, FiltersForList } from "./ProjectsList";
+import ProjectList, { ProjectForList, FiltersForList, TableSorting } from "./ProjectsList";
 import ProjectDataSet from "./ProjectDataSet";
 import ProjectDelete from "./ProjectDelete";
 import {

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -125,7 +125,10 @@ export default class ProjectDashboard {
             id: getUid("dashboard", projectsListDashboard.id),
             name: projectsListDashboard.name,
             dashboardItems: positionItems(items, positionItemsOptions),
-            sharing: new ProjectSharing(config, projectsListDashboard).getSharingAttributesForDashboard(),
+            sharing: new ProjectSharing(
+                config,
+                projectsListDashboard
+            ).getSharingAttributesForDashboard(),
         };
 
         return { dashboards: [dashboard], visualizations };

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -101,59 +101,78 @@ export default class ProjectDashboard {
         if (!_.isNil(minimumOrgUnits) && projectsListDashboard.orgUnits.length < minimumOrgUnits)
             return { dashboards: [], visualizations: [] };
 
-        // Note: I think this.dashboardType === "project" is the same as the condition for minimumOrgUnits = 2
-        // I'll need to check that before doing the PR
-
         const targetVsActualBenefitsChart_ =
             this.dashboardType === "project" ? this.targetVsActualBenefitsChart() : undefined;
+
         const targetVsActualPeopleChart_ =
             this.dashboardType === "project" ? this.targetVsActualPeopleChart() : undefined;
+
         const merTargetVsActualBenefitsChart_ =
             this.dashboardType === "project" ? this.merTargetVsActualBenefitsChart() : undefined;
+
         const merTargetVsActualPeopleChart_ =
             this.dashboardType === "project" ? this.merTargetVsActualPeopleChart() : undefined;
+
         const targetVsActualBenefitsDisaggregatedByIndicatorChart_ =
             this.dashboardType === "project"
                 ? this.targetVsActualBenefitsDisaggregatedByIndicatorChart()
                 : undefined;
+
         const targetVsActualPeopleDisaggregatedByIndicatorChart_ =
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleDisaggregatedByIndicatorChart()
                 : undefined;
+
         const targetVsActualBenefitsLineChart_ =
             this.dashboardType === "project" ? this.targetVsActualBenefitsLineChart() : undefined;
+
         const targetVsActualPeopleLineChart_ =
             this.dashboardType === "project" ? this.targetVsActualPeopleLineChart() : undefined;
+
         const targetVsActualPeopleLineChartMaleOnly_ =
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineChartMaleOnly()
                 : undefined;
+
         const targetVsActualPeopleLineChartFemaleOnly_ =
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineChartFemaleOnly()
                 : undefined;
+
         const targetVsActualPeopleLineColumnChartMaleOnly_ =
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineColumnChartMaleOnly()
                 : undefined;
+
         const targetVsActualPeopleLineColumnChartFemaleOnly_ =
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineColumnChartFemaleOnly()
                 : undefined;
 
+        const targetVsActualBenefitsTable_ = this.targetVsActualBenefitsTable();
+        const targetVsActualBenefitsWithDisaggregationTable_ =
+            this.targetVsActualBenefitsWithDisaggregationTable();
+        const targetVsActualPeopleTable_ = this.targetVsActualPeopleTable();
+        const achievedBenefitsToDateTable_ = this.achievedBenefitsTable({ toDate: true });
+        const achievedBenefitsTotalToDateTable_ = this.achievedBenefitsTotalToDateTable();
+        const achievedPeopleTotalToDateTable_ = this.achievedPeopleTotalTable({ toDate: true });
+        const achievedBenefitsTable_ = this.achievedBenefitsTable();
+        const achievedPeopleToDateTable_ = this.achievedPeopleTable();
+        const achievedPeopleTotalTable_ = this.achievedPeopleTotalTable();
+
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
-            this.targetVsActualBenefitsTable(),
-            this.targetVsActualBenefitsWithDisaggregationTable(),
-            this.targetVsActualPeopleTable(),
+            targetVsActualBenefitsTable_,
+            targetVsActualBenefitsWithDisaggregationTable_,
+            targetVsActualPeopleTable_,
             // Percent achieved (to date)
-            this.achievedBenefitsTable({ toDate: true }),
-            this.achievedBenefitsTotalToDateTable(),
-            this.achievedPeopleTotalTable({ toDate: true }),
+            achievedBenefitsToDateTable_,
+            achievedBenefitsTotalToDateTable_,
+            achievedPeopleTotalToDateTable_,
             // Percent achieved
-            this.achievedBenefitsTable(),
-            this.achievedPeopleTable(),
-            this.achievedPeopleTotalTable(),
+            achievedBenefitsTable_,
+            achievedPeopleToDateTable_,
+            achievedPeopleTotalTable_,
         ]);
 
         const charts: Array<PartialPersistedModel<D2Visualization>> = _.compact([
@@ -162,13 +181,6 @@ export default class ProjectDashboard {
             this.genderChart(),
             this.costBenefitTable(),
         ]);
-
-        const [
-            targetVsActualBenefitsTable_,
-            targetVsActualBenefitsWithDisaggregationTable_,
-            targetVsActualPeopleTable_,
-        ] = reportTables;
-        const otherReportTables = reportTables.slice(3);
 
         const projectVisualizations = _.compact([
             targetVsActualBenefitsChart_,
@@ -185,41 +197,24 @@ export default class ProjectDashboard {
             targetVsActualPeopleLineChartFemaleOnly_,
             targetVsActualPeopleLineColumnChartMaleOnly_,
             targetVsActualPeopleLineColumnChartFemaleOnly_,
-            targetVsActualBenefitsWithDisaggregationTable_,
+            achievedBenefitsToDateTable_,
+            achievedPeopleToDateTable_,
+            ...charts,
         ]);
-        const defaultVisualizations = _.concat(reportTables, _.compact(charts));
-        const favorites = {
-            visualizations:
-                this.dashboardType === "project"
-                    ? _.concat(projectVisualizations, otherReportTables, _.compact(charts))
-                    : defaultVisualizations,
-        };
 
-        const items: Array<PartialModel<D2DashboardItem>> = _.compact([
-            ...(this.dashboardType === "project"
-                ? _.compact([
-                      getChartDashboardItem(targetVsActualBenefitsChart_),
-                      getChartDashboardItem(targetVsActualPeopleChart_),
-                      getChartDashboardItem(merTargetVsActualBenefitsChart_),
-                      getChartDashboardItem(merTargetVsActualPeopleChart_),
-                      getReportTableItem(targetVsActualBenefitsTable_),
-                      getReportTableItem(targetVsActualPeopleTable_),
-                      getChartDashboardItem(targetVsActualBenefitsDisaggregatedByIndicatorChart_),
-                      getChartDashboardItem(targetVsActualPeopleDisaggregatedByIndicatorChart_),
-                      getChartDashboardItem(targetVsActualBenefitsLineChart_),
-                      getChartDashboardItem(targetVsActualPeopleLineChart_),
-                      getChartDashboardItem(targetVsActualPeopleLineChartMaleOnly_),
-                      getChartDashboardItem(targetVsActualPeopleLineChartFemaleOnly_),
-                      getChartDashboardItem(targetVsActualPeopleLineColumnChartMaleOnly_),
-                      getChartDashboardItem(targetVsActualPeopleLineColumnChartFemaleOnly_),
-                      getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
-                  ])
-                : reportTables.map(reportTable => getReportTableItem(reportTable))),
-            ...(this.dashboardType === "project"
-                ? otherReportTables.map(reportTable => getReportTableItem(reportTable))
-                : []),
-            ...charts.map(chart => getChartDashboardItem(chart)),
-        ]);
+        const defaultVisualizations = _.concat(reportTables, _.compact(charts));
+
+        const visualizations =
+            this.dashboardType === "project" ? projectVisualizations : defaultVisualizations;
+
+        const items: Array<PartialModel<D2DashboardItem>> = _(visualizations)
+            .map(visualization =>
+                visualization.type === "PIVOT_TABLE"
+                    ? getReportTableItem(visualization)
+                    : getChartDashboardItem(visualization)
+            )
+            .compact()
+            .value();
 
         const positionItemsOptions: PositionItemsOptions = {
             maxWidth: toItemWidth(100),
@@ -234,7 +229,7 @@ export default class ProjectDashboard {
             ...new ProjectSharing(config, projectsListDashboard).getSharingAttributesForDashboard(),
         };
 
-        return { dashboards: [dashboard], ...favorites };
+        return { dashboards: [dashboard], visualizations };
     }
 
     targetVsActualBenefitsTable(): MaybeD2Visualization {

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -163,7 +163,6 @@ export default class ProjectDashboard {
             this.costBenefitTable(),
         ]);
 
-        const achievedMonthlyChart_ = this.achievedMonthlyChart();
         const [
             targetVsActualBenefitsTable_,
             targetVsActualBenefitsWithDisaggregationTable_,
@@ -188,18 +187,11 @@ export default class ProjectDashboard {
             targetVsActualPeopleLineColumnChartFemaleOnly_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
-        const defaultVisualizations = _.concat(
-            reportTables,
-            _.compact([achievedMonthlyChart_, ...charts])
-        );
+        const defaultVisualizations = _.concat(reportTables, _.compact(charts));
         const favorites = {
             visualizations:
                 this.dashboardType === "project"
-                    ? _.concat(
-                          projectVisualizations,
-                          otherReportTables,
-                          _.compact([achievedMonthlyChart_, ...charts])
-                      )
+                    ? _.concat(projectVisualizations, otherReportTables, _.compact(charts))
                     : defaultVisualizations,
         };
 
@@ -226,7 +218,6 @@ export default class ProjectDashboard {
             ...(this.dashboardType === "project"
                 ? otherReportTables.map(reportTable => getReportTableItem(reportTable))
                 : []),
-            getChartDashboardItem(achievedMonthlyChart_, { width: toItemWidth(100) }),
             ...charts.map(chart => getChartDashboardItem(chart)),
         ]);
 

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -101,6 +101,10 @@ export default class ProjectDashboard {
             this.dashboardType === "project" ? this.merTargetVsActualBenefitsChart() : undefined;
         const merTargetVsActualPeopleChart_ =
             this.dashboardType === "project" ? this.merTargetVsActualPeopleChart() : undefined;
+        const targetVsActualBenefitsDisaggregatedByIndicatorChart_ =
+            this.dashboardType === "project"
+                ? this.targetVsActualBenefitsDisaggregatedByIndicatorChart()
+                : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -125,25 +129,54 @@ export default class ProjectDashboard {
         ]);
 
         const achievedMonthlyChart_ = this.achievedMonthlyChart();
+        const [
+            targetVsActualBenefitsTable_,
+            targetVsActualBenefitsWithDisaggregationTable_,
+            targetVsActualPeopleTable_,
+        ] = reportTables;
+        const otherReportTables = reportTables.slice(3);
+
+        const projectVisualizations = _.compact([
+            targetVsActualBenefitsChart_,
+            targetVsActualPeopleChart_,
+            merTargetVsActualBenefitsChart_,
+            merTargetVsActualPeopleChart_,
+            targetVsActualBenefitsTable_,
+            targetVsActualPeopleTable_,
+            targetVsActualBenefitsDisaggregatedByIndicatorChart_,
+            targetVsActualBenefitsWithDisaggregationTable_,
+        ]);
+        const defaultVisualizations = _.concat(
+            reportTables,
+            _.compact([achievedMonthlyChart_, ...charts])
+        );
         const favorites = {
-            visualizations: _.concat(
-                _.compact([
-                    targetVsActualBenefitsChart_,
-                    targetVsActualPeopleChart_,
-                    merTargetVsActualBenefitsChart_,
-                    merTargetVsActualPeopleChart_,
-                ]),
-                reportTables,
-                _.compact([achievedMonthlyChart_, ...charts])
-            ),
+            visualizations:
+                this.dashboardType === "project"
+                    ? _.concat(
+                          projectVisualizations,
+                          otherReportTables,
+                          _.compact([achievedMonthlyChart_, ...charts])
+                      )
+                    : defaultVisualizations,
         };
 
         const items: Array<PartialModel<D2DashboardItem>> = _.compact([
-            getChartDashboardItem(targetVsActualBenefitsChart_),
-            getChartDashboardItem(targetVsActualPeopleChart_),
-            getChartDashboardItem(merTargetVsActualBenefitsChart_),
-            getChartDashboardItem(merTargetVsActualPeopleChart_),
-            ...reportTables.map(reportTable => getReportTableItem(reportTable)),
+            ...(this.dashboardType === "project"
+                ? _.compact([
+                      getChartDashboardItem(targetVsActualBenefitsChart_),
+                      getChartDashboardItem(targetVsActualPeopleChart_),
+                      getChartDashboardItem(merTargetVsActualBenefitsChart_),
+                      getChartDashboardItem(merTargetVsActualPeopleChart_),
+                      getReportTableItem(targetVsActualBenefitsTable_),
+                      getReportTableItem(targetVsActualPeopleTable_),
+                      getChartDashboardItem(targetVsActualBenefitsDisaggregatedByIndicatorChart_),
+                      getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
+                  ])
+                : reportTables.map(reportTable => getReportTableItem(reportTable))),
+            ...(this.dashboardType === "project"
+                ? otherReportTables.map(reportTable => getReportTableItem(reportTable))
+                : []),
             getChartDashboardItem(achievedMonthlyChart_, { width: toItemWidth(100) }),
             ...charts.map(chart => getChartDashboardItem(chart)),
         ]);
@@ -247,6 +280,23 @@ export default class ProjectDashboard {
             ],
             columns: [config.categories.targetActual],
             rows: [dimensions.period],
+        });
+    }
+
+    targetVsActualBenefitsDisaggregatedByIndicatorChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const dataElementsNoDisaggregated = dataElements.benefit.filter(
+            de => !de.categories.includes("newRecurring")
+        );
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-target-actual-benefits-disaggregated-by-indicator",
+            name: i18n.t("Target vs Actual - Benefits - Column Chart Disaggregated By Indicator"),
+            items: dataElementItems(dataElementsNoDisaggregated),
+            filters: [dimensions.orgUnit],
+            columns: [dimensions.data],
+            rows: [dimensions.period, config.categories.targetActual],
         });
     }
 

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -34,7 +34,11 @@ export default class ProjectDashboard {
     dataElements: ProjectsListDashboard["dataElements"];
     categoryOnlyNew: { id: Id; categoryOptions: Ref[] };
 
-    constructor(private config: Config, private projectsListDashboard: ProjectsListDashboard) {
+    constructor(
+        private config: Config,
+        private projectsListDashboard: ProjectsListDashboard,
+        private dashboardType: "project" | "awardNumber"
+    ) {
         this.dataElements = this.projectsListDashboard.dataElements;
 
         this.categoryOnlyNew = {
@@ -53,7 +57,7 @@ export default class ProjectDashboard {
     ): Promise<ProjectDashboard> {
         const condition: Condition = { type: "project", id: project.id, initialMetadata };
         const projectsListDashboard = await getProjectsListDashboard(api, config, condition);
-        return new ProjectDashboard(config, projectsListDashboard);
+        return new ProjectDashboard(config, projectsListDashboard, "project");
     }
 
     static async buildForAwardNumber(
@@ -64,7 +68,7 @@ export default class ProjectDashboard {
     ): Promise<ProjectDashboard> {
         const condition: Condition = { type: "awardNumber", value: awardNumber, initialMetadata };
         const projectsListDashboard = await getProjectsListDashboard(api, config, condition);
-        return new ProjectDashboard(config, projectsListDashboard);
+        return new ProjectDashboard(config, projectsListDashboard, "awardNumber");
     }
 
     generate(options: { minimumOrgUnits?: number } = {}) {
@@ -73,6 +77,12 @@ export default class ProjectDashboard {
 
         if (!_.isNil(minimumOrgUnits) && projectsListDashboard.orgUnits.length < minimumOrgUnits)
             return { dashboards: [], visualizations: [] };
+
+        // Note: I think this.dashboardType === "project" is the same as the condition for minimumOrgUnits = 2
+        // I'll need to check that before doing the PR
+
+        const targetVsActualBenefitsChart_ =
+            this.dashboardType === "project" ? this.targetVsActualBenefitsChart() : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -99,10 +109,15 @@ export default class ProjectDashboard {
 
         const achievedMonthlyChart_ = this.achievedMonthlyChart();
         const favorites = {
-            visualizations: _.concat(reportTables, _.compact([achievedMonthlyChart_, ...charts])),
+            visualizations: _.concat(
+                _.compact([targetVsActualBenefitsChart_]),
+                reportTables,
+                _.compact([achievedMonthlyChart_, ...charts])
+            ),
         };
 
         const items: Array<PartialModel<D2DashboardItem>> = _.compact([
+            getChartDashboardItem(targetVsActualBenefitsChart_),
             ...reportTables.map(reportTable => getReportTableItem(reportTable)),
             getChartDashboardItem(achievedMonthlyChart_, { width: toItemWidth(100) }),
             ...charts.map(chart => getChartDashboardItem(chart)),
@@ -138,6 +153,23 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit],
             columns: [dimensions.period],
             rows: [dimensions.data, config.categories.targetActual],
+        });
+    }
+
+    targetVsActualBenefitsChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const dataElementsNoDisaggregated = dataElements.benefit.filter(
+            de => !de.categories.includes("newRecurring")
+        );
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-target-actual-benefits",
+            name: i18n.t("Target vs Actual - Benefits - Column Chart"),
+            items: dataElementItems(dataElementsNoDisaggregated),
+            filters: [dimensions.data, dimensions.orgUnit],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.period],
         });
     }
 

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -125,7 +125,7 @@ export default class ProjectDashboard {
             id: getUid("dashboard", projectsListDashboard.id),
             name: projectsListDashboard.name,
             dashboardItems: positionItems(items, positionItemsOptions),
-            ...new ProjectSharing(config, projectsListDashboard).getSharingAttributesForDashboard(),
+            sharing: new ProjectSharing(config, projectsListDashboard).getSharingAttributesForDashboard(),
         };
 
         return { dashboards: [dashboard], visualizations };
@@ -643,7 +643,7 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit],
             columns: [dimensions.period],
             rows: [dimensions.data],
-            extra: { legendSet: config.legendSets.achieved },
+            extra: { legend: { set: config.legendSets.achieved } },
             ...options,
         });
     }
@@ -660,7 +660,7 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit],
             columns: [dimensions.period],
             rows: [dimensions.data],
-            extra: { legendSet: config.legendSets.achieved },
+            extra: { legend: { set: config.legendSets.achieved } },
             rowTotals: false,
         });
     }
@@ -678,7 +678,7 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit, dimensions.period],
             columns: [this.categoryOnlyNew],
             rows: [dimensions.data],
-            extra: { legendSet: config.legendSets.achieved },
+            extra: { legend: { set: config.legendSets.achieved } },
             rowTotals: false,
             ...options,
         });
@@ -701,7 +701,7 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit, dimensions.period],
             columns: [this.categoryOnlyNew],
             rows: [dimensions.data],
-            extra: { legendSet: config.legendSets.achieved },
+            extra: { legend: { set: config.legendSets.achieved } },
             rowTotals: false,
         });
     }

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -99,6 +99,8 @@ export default class ProjectDashboard {
             this.dashboardType === "project" ? this.targetVsActualPeopleChart() : undefined;
         const merTargetVsActualBenefitsChart_ =
             this.dashboardType === "project" ? this.merTargetVsActualBenefitsChart() : undefined;
+        const merTargetVsActualPeopleChart_ =
+            this.dashboardType === "project" ? this.merTargetVsActualPeopleChart() : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -130,6 +132,7 @@ export default class ProjectDashboard {
                     targetVsActualBenefitsChart_,
                     targetVsActualPeopleChart_,
                     merTargetVsActualBenefitsChart_,
+                    merTargetVsActualPeopleChart_,
                 ]),
                 reportTables,
                 _.compact([achievedMonthlyChart_, ...charts])
@@ -140,6 +143,7 @@ export default class ProjectDashboard {
             getChartDashboardItem(targetVsActualBenefitsChart_),
             getChartDashboardItem(targetVsActualPeopleChart_),
             getChartDashboardItem(merTargetVsActualBenefitsChart_),
+            getChartDashboardItem(merTargetVsActualPeopleChart_),
             ...reportTables.map(reportTable => getReportTableItem(reportTable)),
             getChartDashboardItem(achievedMonthlyChart_, { width: toItemWidth(100) }),
             ...charts.map(chart => getChartDashboardItem(chart)),
@@ -223,6 +227,25 @@ export default class ProjectDashboard {
             name: i18n.t("MER - Target vs Actual - Benefits - Column Chart"),
             items: dataElementItems(merDataElements.benefit),
             filters: [dimensions.orgUnit],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.period],
+        });
+    }
+
+    merTargetVsActualPeopleChart(): MaybeD2Visualization {
+        const { config, merDataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-mer-target-actual-people",
+            name: i18n.t("MER - Target vs Actual - People - Column Chart"),
+            items: dataElementItems(merDataElements.people),
+            filters: [
+                dimensions.data,
+                dimensions.orgUnit,
+                config.categories.gender,
+                config.categories.newRecurring,
+            ],
             columns: [config.categories.targetActual],
             rows: [dimensions.period],
         });

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -109,6 +109,8 @@ export default class ProjectDashboard {
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleDisaggregatedByIndicatorChart()
                 : undefined;
+        const targetVsActualBenefitsLineChart_ =
+            this.dashboardType === "project" ? this.targetVsActualBenefitsLineChart() : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -149,6 +151,7 @@ export default class ProjectDashboard {
             targetVsActualPeopleTable_,
             targetVsActualBenefitsDisaggregatedByIndicatorChart_,
             targetVsActualPeopleDisaggregatedByIndicatorChart_,
+            targetVsActualBenefitsLineChart_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -177,6 +180,7 @@ export default class ProjectDashboard {
                       getReportTableItem(targetVsActualPeopleTable_),
                       getChartDashboardItem(targetVsActualBenefitsDisaggregatedByIndicatorChart_),
                       getChartDashboardItem(targetVsActualPeopleDisaggregatedByIndicatorChart_),
+                      getChartDashboardItem(targetVsActualBenefitsLineChart_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -317,6 +321,24 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit, config.categories.gender, config.categories.newRecurring],
             columns: [dimensions.data],
             rows: [dimensions.period, config.categories.targetActual],
+        });
+    }
+
+    targetVsActualBenefitsLineChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const dataElementsNoDisaggregated = dataElements.benefit.filter(
+            de => !de.categories.includes("newRecurring")
+        );
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            chartType: "LINE",
+            key: "chart-target-actual-benefits-line",
+            name: i18n.t("Target vs Actual - Benefits - Line Chart"),
+            items: dataElementItems(dataElementsNoDisaggregated),
+            filters: [dimensions.orgUnit],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.data, dimensions.period],
         });
     }
 

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -32,14 +32,26 @@ import { filterPeriods } from "./Period";
 
 export default class ProjectDashboard {
     dataElements: ProjectsListDashboard["dataElements"];
+    merDataElements: Record<"all" | "people" | "benefit", Ref[]>;
     categoryOnlyNew: { id: Id; categoryOptions: Ref[] };
 
     constructor(
         private config: Config,
         private projectsListDashboard: ProjectsListDashboard,
-        private dashboardType: "project" | "awardNumber"
+        private dashboardType: "project" | "awardNumber",
+        project?: Project
     ) {
         this.dataElements = this.projectsListDashboard.dataElements;
+
+        const projectMerDataElements = _(project?.dataElementsMER.getAllSelected())
+            .uniqBy(de => de.id)
+            .value();
+
+        this.merDataElements = {
+            all: projectMerDataElements,
+            people: projectMerDataElements.filter(de => de.peopleOrBenefit === "people"),
+            benefit: projectMerDataElements.filter(de => de.peopleOrBenefit === "benefit"),
+        };
 
         this.categoryOnlyNew = {
             id: config.categories.newRecurring.id,
@@ -52,12 +64,12 @@ export default class ProjectDashboard {
     static async buildForProject(
         api: D2Api,
         config: Config,
-        project: Ref,
+        project: Project,
         initialMetadata?: DashboardSourceMetadata
     ): Promise<ProjectDashboard> {
         const condition: Condition = { type: "project", id: project.id, initialMetadata };
         const projectsListDashboard = await getProjectsListDashboard(api, config, condition);
-        return new ProjectDashboard(config, projectsListDashboard, "project");
+        return new ProjectDashboard(config, projectsListDashboard, "project", project);
     }
 
     static async buildForAwardNumber(
@@ -85,6 +97,8 @@ export default class ProjectDashboard {
             this.dashboardType === "project" ? this.targetVsActualBenefitsChart() : undefined;
         const targetVsActualPeopleChart_ =
             this.dashboardType === "project" ? this.targetVsActualPeopleChart() : undefined;
+        const merTargetVsActualBenefitsChart_ =
+            this.dashboardType === "project" ? this.merTargetVsActualBenefitsChart() : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -112,7 +126,11 @@ export default class ProjectDashboard {
         const achievedMonthlyChart_ = this.achievedMonthlyChart();
         const favorites = {
             visualizations: _.concat(
-                _.compact([targetVsActualBenefitsChart_, targetVsActualPeopleChart_]),
+                _.compact([
+                    targetVsActualBenefitsChart_,
+                    targetVsActualPeopleChart_,
+                    merTargetVsActualBenefitsChart_,
+                ]),
                 reportTables,
                 _.compact([achievedMonthlyChart_, ...charts])
             ),
@@ -121,6 +139,7 @@ export default class ProjectDashboard {
         const items: Array<PartialModel<D2DashboardItem>> = _.compact([
             getChartDashboardItem(targetVsActualBenefitsChart_),
             getChartDashboardItem(targetVsActualPeopleChart_),
+            getChartDashboardItem(merTargetVsActualBenefitsChart_),
             ...reportTables.map(reportTable => getReportTableItem(reportTable)),
             getChartDashboardItem(achievedMonthlyChart_, { width: toItemWidth(100) }),
             ...charts.map(chart => getChartDashboardItem(chart)),
@@ -190,6 +209,20 @@ export default class ProjectDashboard {
                 config.categories.gender,
                 config.categories.newRecurring,
             ],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.period],
+        });
+    }
+
+    merTargetVsActualBenefitsChart(): MaybeD2Visualization {
+        const { config, merDataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-mer-target-actual-benefits",
+            name: i18n.t("MER - Target vs Actual - Benefits - Column Chart"),
+            items: dataElementItems(merDataElements.benefit),
+            filters: [dimensions.orgUnit],
             columns: [config.categories.targetActual],
             rows: [dimensions.period],
         });

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -28,7 +28,7 @@ import {
     DashboardSourceMetadata,
     Condition,
 } from "./ProjectsListDashboard";
-import { filterPeriods } from "./Period";
+import { getVisualizationPeriods } from "./Period";
 
 export default class ProjectDashboard {
     dataElements: ProjectsListDashboard["dataElements"];
@@ -101,111 +101,10 @@ export default class ProjectDashboard {
         if (!_.isNil(minimumOrgUnits) && projectsListDashboard.orgUnits.length < minimumOrgUnits)
             return { dashboards: [], visualizations: [] };
 
-        const targetVsActualBenefitsChart_ =
-            this.dashboardType === "project" ? this.targetVsActualBenefitsChart() : undefined;
-
-        const targetVsActualPeopleChart_ =
-            this.dashboardType === "project" ? this.targetVsActualPeopleChart() : undefined;
-
-        const merTargetVsActualBenefitsChart_ =
-            this.dashboardType === "project" ? this.merTargetVsActualBenefitsChart() : undefined;
-
-        const merTargetVsActualPeopleChart_ =
-            this.dashboardType === "project" ? this.merTargetVsActualPeopleChart() : undefined;
-
-        const targetVsActualBenefitsDisaggregatedByIndicatorChart_ =
-            this.dashboardType === "project"
-                ? this.targetVsActualBenefitsDisaggregatedByIndicatorChart()
-                : undefined;
-
-        const targetVsActualPeopleDisaggregatedByIndicatorChart_ =
-            this.dashboardType === "project"
-                ? this.targetVsActualPeopleDisaggregatedByIndicatorChart()
-                : undefined;
-
-        const targetVsActualBenefitsLineChart_ =
-            this.dashboardType === "project" ? this.targetVsActualBenefitsLineChart() : undefined;
-
-        const targetVsActualPeopleLineChart_ =
-            this.dashboardType === "project" ? this.targetVsActualPeopleLineChart() : undefined;
-
-        const targetVsActualPeopleLineChartMaleOnly_ =
-            this.dashboardType === "project"
-                ? this.targetVsActualPeopleLineChartMaleOnly()
-                : undefined;
-
-        const targetVsActualPeopleLineChartFemaleOnly_ =
-            this.dashboardType === "project"
-                ? this.targetVsActualPeopleLineChartFemaleOnly()
-                : undefined;
-
-        const targetVsActualPeopleLineColumnChartMaleOnly_ =
-            this.dashboardType === "project"
-                ? this.targetVsActualPeopleLineColumnChartMaleOnly()
-                : undefined;
-
-        const targetVsActualPeopleLineColumnChartFemaleOnly_ =
-            this.dashboardType === "project"
-                ? this.targetVsActualPeopleLineColumnChartFemaleOnly()
-                : undefined;
-
-        const targetVsActualBenefitsTable_ = this.targetVsActualBenefitsTable();
-        const targetVsActualBenefitsWithDisaggregationTable_ =
-            this.targetVsActualBenefitsWithDisaggregationTable();
-        const targetVsActualPeopleTable_ = this.targetVsActualPeopleTable();
-        const achievedBenefitsToDateTable_ = this.achievedBenefitsTable({ toDate: true });
-        const achievedBenefitsTotalToDateTable_ = this.achievedBenefitsTotalToDateTable();
-        const achievedPeopleTotalToDateTable_ = this.achievedPeopleTotalTable({ toDate: true });
-        const achievedBenefitsTable_ = this.achievedBenefitsTable();
-        const achievedPeopleToDateTable_ = this.achievedPeopleTable();
-        const achievedPeopleTotalTable_ = this.achievedPeopleTotalTable();
-
-        const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
-            // General Data View
-            targetVsActualBenefitsTable_,
-            targetVsActualBenefitsWithDisaggregationTable_,
-            targetVsActualPeopleTable_,
-            // Percent achieved (to date)
-            achievedBenefitsToDateTable_,
-            achievedBenefitsTotalToDateTable_,
-            achievedPeopleTotalToDateTable_,
-            // Percent achieved
-            achievedBenefitsTable_,
-            achievedPeopleToDateTable_,
-            achievedPeopleTotalTable_,
-        ]);
-
-        const charts: Array<PartialPersistedModel<D2Visualization>> = _.compact([
-            this.achievedBenefitChart(),
-            this.achievedPeopleChart(),
-            this.genderChart(),
-            this.costBenefitTable(),
-        ]);
-
-        const projectVisualizations = _.compact([
-            targetVsActualBenefitsChart_,
-            targetVsActualPeopleChart_,
-            merTargetVsActualBenefitsChart_,
-            merTargetVsActualPeopleChart_,
-            targetVsActualBenefitsTable_,
-            targetVsActualPeopleTable_,
-            targetVsActualBenefitsDisaggregatedByIndicatorChart_,
-            targetVsActualPeopleDisaggregatedByIndicatorChart_,
-            targetVsActualBenefitsLineChart_,
-            targetVsActualPeopleLineChart_,
-            targetVsActualPeopleLineChartMaleOnly_,
-            targetVsActualPeopleLineChartFemaleOnly_,
-            targetVsActualPeopleLineColumnChartMaleOnly_,
-            targetVsActualPeopleLineColumnChartFemaleOnly_,
-            achievedBenefitsToDateTable_,
-            achievedPeopleToDateTable_,
-            ...charts,
-        ]);
-
-        const defaultVisualizations = _.concat(reportTables, _.compact(charts));
-
         const visualizations =
-            this.dashboardType === "project" ? projectVisualizations : defaultVisualizations;
+            this.dashboardType === "project"
+                ? this.getProjectVisualizations()
+                : this.getAwardNumberVisualizations();
 
         const items: Array<PartialModel<D2DashboardItem>> = _(visualizations)
             .map(visualization =>
@@ -232,6 +131,58 @@ export default class ProjectDashboard {
         return { dashboards: [dashboard], visualizations };
     }
 
+    getProjectVisualizations(): PartialPersistedModel<D2Visualization>[] {
+        const targetVsActualBenefitsTable_ = this.targetVsActualBenefitsTable();
+        const targetVsActualPeopleTable_ = this.targetVsActualPeopleTable();
+        const achievedBenefitsToDateTable_ = this.achievedBenefitsTable({ toDate: true });
+        const achievedPeopleToDateTable_ = this.achievedPeopleTable();
+        const charts: Array<PartialPersistedModel<D2Visualization>> = _.compact([
+            this.achievedBenefitChart(),
+            this.achievedPeopleChart(),
+            this.genderChart(),
+            this.costBenefitTable(),
+        ]);
+
+        return _.compact([
+            this.targetVsActualBenefitsChart(),
+            this.targetVsActualPeopleChart(),
+            this.merTargetVsActualBenefitsChart(),
+            this.merTargetVsActualPeopleChart(),
+            targetVsActualBenefitsTable_,
+            targetVsActualPeopleTable_,
+            this.targetVsActualBenefitsDisaggregatedByIndicatorChart(),
+            this.targetVsActualPeopleDisaggregatedByIndicatorChart(),
+            this.targetVsActualBenefitsLineChart(),
+            this.targetVsActualPeopleLineChart(),
+            this.targetVsActualPeopleLineChartMaleOnly(),
+            this.targetVsActualPeopleLineChartFemaleOnly(),
+            this.targetVsActualPeopleLineColumnChartMaleOnly(),
+            this.targetVsActualPeopleLineColumnChartFemaleOnly(),
+            achievedBenefitsToDateTable_,
+            achievedPeopleToDateTable_,
+            ...charts,
+        ]);
+    }
+
+    getAwardNumberVisualizations(): PartialPersistedModel<D2Visualization>[] {
+        return _.compact([
+            this.awardNumberTargetVsActualPeoplePivotTable(),
+            this.awardNumberTargetVsActualPeopleColumnChart(),
+            this.awardNumberTargetVsActualBenefitsPivotTable(),
+            this.awardNumberTargetVsActualBenefitsColumnChart(),
+            this.achievedPeopleTotalTable({ toDate: true }),
+            this.achievedBenefitsTable({ toDate: true }),
+            this.targetVsActualPeopleTable(),
+            this.targetVsActualBenefitsTable(),
+            this.awardNumberTargetVsActualPeopleMonthByMonthTable(),
+            this.awardNumberTargetVsActualBenefitsMonthByMonthTable(),
+            this.awardNumberTargetVsActualPeopleMaleOnlyPivotTable(),
+            this.awardNumberTargetVsActualPeopleMaleOnlyColumnChart(),
+            this.awardNumberTargetVsActualPeopleFemaleOnlyPivotTable(),
+            this.awardNumberTargetVsActualPeopleFemaleOnlyColumnChart(),
+        ]);
+    }
+
     targetVsActualBenefitsTable(): MaybeD2Visualization {
         const { config, dataElements } = this;
         const dataElementsNoDisaggregated = dataElements.benefit.filter(
@@ -242,6 +193,24 @@ export default class ProjectDashboard {
             type: "table",
             key: "reportTable-target-actual-benefits",
             name: i18n.t("Target vs Actual - Benefits"),
+            items: dataElementItems(dataElementsNoDisaggregated),
+            filters: [dimensions.orgUnit],
+            columns: [dimensions.period],
+            rows: [dimensions.data, config.categories.targetActual],
+        });
+    }
+
+    awardNumberTargetVsActualBenefitsPivotTable(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const dataElementsNoDisaggregated = dataElements.benefit.filter(
+            de => !de.categories.includes("newRecurring")
+        );
+
+        return this.getD2VisualizationFromDefinition({
+            type: "table",
+            key: "reportTable-target-actual-benefits-pivot-table",
+            name: i18n.t("Target vs Actual - Benefits - Pivot Table"),
+            periodStrategy: "yearly",
             items: dataElementItems(dataElementsNoDisaggregated),
             filters: [dimensions.orgUnit],
             columns: [dimensions.period],
@@ -266,6 +235,24 @@ export default class ProjectDashboard {
         });
     }
 
+    awardNumberTargetVsActualBenefitsColumnChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const dataElementsNoDisaggregated = dataElements.benefit.filter(
+            de => !de.categories.includes("newRecurring")
+        );
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-target-actual-benefits-award-number",
+            name: i18n.t("Target vs Actual - Benefits - Column Chart"),
+            periodStrategy: "yearly",
+            items: dataElementItems(dataElementsNoDisaggregated),
+            filters: [dimensions.orgUnit],
+            columns: [dimensions.data],
+            rows: [config.categories.targetActual, dimensions.period],
+        });
+    }
+
     targetVsActualPeopleChart(): MaybeD2Visualization {
         const { config, dataElements } = this;
 
@@ -282,6 +269,21 @@ export default class ProjectDashboard {
             ],
             columns: [config.categories.targetActual],
             rows: [dimensions.period],
+        });
+    }
+
+    awardNumberTargetVsActualPeopleColumnChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-target-actual-people-award-number",
+            name: i18n.t("Target vs Actual - People - Column Chart"),
+            periodStrategy: "yearly",
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, config.categories.gender, config.categories.newRecurring],
+            columns: [dimensions.data],
+            rows: [config.categories.targetActual, dimensions.period],
         });
     }
 
@@ -493,6 +495,126 @@ export default class ProjectDashboard {
         });
     }
 
+    awardNumberTargetVsActualPeoplePivotTable(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "table",
+            key: "reportTable-target-actual-people-pivot-table",
+            name: i18n.t("Target vs Actual - People - Pivot Table"),
+            periodStrategy: "yearly",
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit],
+            columns: [dimensions.period],
+            rows: [dimensions.data, config.categories.targetActual, config.categories.newRecurring],
+        });
+    }
+
+    awardNumberTargetVsActualPeopleMonthByMonthTable(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "table",
+            key: "reportTable-target-actual-people-month-by-month",
+            name: i18n.t("Target vs Actual - People - Month by Month"),
+            periodStrategy: "monthly_interleaved_by_month",
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, config.categories.gender, config.categories.newRecurring],
+            columns: [dimensions.period],
+            rows: [dimensions.data, config.categories.targetActual],
+        });
+    }
+
+    awardNumberTargetVsActualBenefitsMonthByMonthTable(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const dataElementsNoDisaggregated = dataElements.benefit.filter(
+            de => !de.categories.includes("newRecurring")
+        );
+
+        return this.getD2VisualizationFromDefinition({
+            type: "table",
+            key: "reportTable-target-actual-benefits-month-by-month",
+            name: i18n.t("Target vs Actual - Benefits - Month by Month"),
+            periodStrategy: "monthly_interleaved_by_month",
+            items: dataElementItems(dataElementsNoDisaggregated),
+            filters: [dimensions.orgUnit],
+            columns: [dimensions.period],
+            rows: [dimensions.data, config.categories.targetActual],
+        });
+    }
+
+    awardNumberTargetVsActualPeopleMaleOnlyPivotTable(): MaybeD2Visualization {
+        return this.awardNumberTargetVsActualPeopleGenderPivotTable({
+            key: "reportTable-target-actual-people-male-only-pivot-table",
+            name: i18n.t("Target vs Actual - People - Male Only - Pivot Table"),
+            genderFilter: this.categoryOnlyMale,
+        });
+    }
+
+    awardNumberTargetVsActualPeopleFemaleOnlyPivotTable(): MaybeD2Visualization {
+        return this.awardNumberTargetVsActualPeopleGenderPivotTable({
+            key: "reportTable-target-actual-people-female-only-pivot-table",
+            name: i18n.t("Target vs Actual - People - Female Only - Pivot Table"),
+            genderFilter: this.categoryOnlyFemale,
+        });
+    }
+
+    awardNumberTargetVsActualPeopleMaleOnlyColumnChart(): MaybeD2Visualization {
+        return this.awardNumberTargetVsActualPeopleGenderColumnChart({
+            key: "chart-target-actual-people-male-only-award-number",
+            name: i18n.t("Target vs Actual - People - Male Only - Column Chart"),
+            genderFilter: this.categoryOnlyMale,
+        });
+    }
+
+    awardNumberTargetVsActualPeopleFemaleOnlyColumnChart(): MaybeD2Visualization {
+        return this.awardNumberTargetVsActualPeopleGenderColumnChart({
+            key: "chart-target-actual-people-female-only-award-number",
+            name: i18n.t("Target vs Actual - People - Female Only - Column Chart"),
+            genderFilter: this.categoryOnlyFemale,
+        });
+    }
+
+    awardNumberTargetVsActualPeopleGenderPivotTable(options: {
+        key: string;
+        name: string;
+        genderFilter: { id: Id; categoryOptions: Ref[] };
+    }): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const { key, name, genderFilter } = options;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "table",
+            key,
+            name,
+            periodStrategy: "yearly",
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, genderFilter, this.categoryOnlyNew],
+            columns: [dimensions.period],
+            rows: [dimensions.data, config.categories.targetActual],
+        });
+    }
+
+    awardNumberTargetVsActualPeopleGenderColumnChart(options: {
+        key: string;
+        name: string;
+        genderFilter: { id: Id; categoryOptions: Ref[] };
+    }): MaybeD2Visualization {
+        const { config, dataElements } = this;
+        const { key, name, genderFilter } = options;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key,
+            name,
+            periodStrategy: "yearly",
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, genderFilter, this.categoryOnlyNew],
+            columns: [dimensions.period],
+            rows: [dimensions.data, config.categories.targetActual],
+        });
+    }
+
     targetVsActualUniquePeopleTable(): MaybeD2Visualization {
         const { config, dataElements } = this;
 
@@ -664,7 +786,7 @@ export default class ProjectDashboard {
             key: definition.key + projectsListDashboard.id,
             name: `${projectsListDashboard.name} - ${definition.name}`,
             organisationUnits: projectsListDashboard.orgUnits,
-            periods: filterPeriods(projectsListDashboard.periods, definition),
+            periods: getVisualizationPeriods(projectsListDashboard.periods, definition),
             sharing: new ProjectSharing(
                 config,
                 projectsListDashboard

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -111,6 +111,8 @@ export default class ProjectDashboard {
                 : undefined;
         const targetVsActualBenefitsLineChart_ =
             this.dashboardType === "project" ? this.targetVsActualBenefitsLineChart() : undefined;
+        const targetVsActualPeopleLineChart_ =
+            this.dashboardType === "project" ? this.targetVsActualPeopleLineChart() : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -152,6 +154,7 @@ export default class ProjectDashboard {
             targetVsActualBenefitsDisaggregatedByIndicatorChart_,
             targetVsActualPeopleDisaggregatedByIndicatorChart_,
             targetVsActualBenefitsLineChart_,
+            targetVsActualPeopleLineChart_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -181,6 +184,7 @@ export default class ProjectDashboard {
                       getChartDashboardItem(targetVsActualBenefitsDisaggregatedByIndicatorChart_),
                       getChartDashboardItem(targetVsActualPeopleDisaggregatedByIndicatorChart_),
                       getChartDashboardItem(targetVsActualBenefitsLineChart_),
+                      getChartDashboardItem(targetVsActualPeopleLineChart_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -337,6 +341,21 @@ export default class ProjectDashboard {
             name: i18n.t("Target vs Actual - Benefits - Line Chart"),
             items: dataElementItems(dataElementsNoDisaggregated),
             filters: [dimensions.orgUnit],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.data, dimensions.period],
+        });
+    }
+
+    targetVsActualPeopleLineChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            chartType: "LINE",
+            key: "chart-target-actual-people-line",
+            name: i18n.t("Target vs Actual - People - Line Chart"),
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, config.categories.gender, config.categories.newRecurring],
             columns: [config.categories.targetActual],
             rows: [dimensions.data, dimensions.period],
         });

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -35,6 +35,7 @@ export default class ProjectDashboard {
     merDataElements: Record<"all" | "people" | "benefit", Ref[]>;
     categoryOnlyNew: { id: Id; categoryOptions: Ref[] };
     categoryOnlyMale: { id: Id; categoryOptions: Ref[] };
+    categoryOnlyFemale: { id: Id; categoryOptions: Ref[] };
 
     constructor(
         private config: Config,
@@ -62,6 +63,10 @@ export default class ProjectDashboard {
         this.categoryOnlyMale = {
             id: config.categories.gender.id,
             categoryOptions: [{ id: config.categoryOptions.male.id }],
+        };
+        this.categoryOnlyFemale = {
+            id: config.categories.gender.id,
+            categoryOptions: [{ id: config.categoryOptions.female.id }],
         };
 
         this.config = config;
@@ -123,6 +128,10 @@ export default class ProjectDashboard {
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineChartMaleOnly()
                 : undefined;
+        const targetVsActualPeopleLineChartFemaleOnly_ =
+            this.dashboardType === "project"
+                ? this.targetVsActualPeopleLineChartFemaleOnly()
+                : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -166,6 +175,7 @@ export default class ProjectDashboard {
             targetVsActualBenefitsLineChart_,
             targetVsActualPeopleLineChart_,
             targetVsActualPeopleLineChartMaleOnly_,
+            targetVsActualPeopleLineChartFemaleOnly_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -197,6 +207,7 @@ export default class ProjectDashboard {
                       getChartDashboardItem(targetVsActualBenefitsLineChart_),
                       getChartDashboardItem(targetVsActualPeopleLineChart_),
                       getChartDashboardItem(targetVsActualPeopleLineChartMaleOnly_),
+                      getChartDashboardItem(targetVsActualPeopleLineChartFemaleOnly_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -383,6 +394,21 @@ export default class ProjectDashboard {
             name: i18n.t("Target vs Actual - People - Line Chart - Male Only"),
             items: dataElementItems(dataElements.people),
             filters: [dimensions.orgUnit, this.categoryOnlyMale, config.categories.newRecurring],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.data, dimensions.period],
+        });
+    }
+
+    targetVsActualPeopleLineChartFemaleOnly(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            chartType: "LINE",
+            key: "chart-target-actual-people-line-female-only",
+            name: i18n.t("Target vs Actual - People - Line Chart - Female Only"),
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, this.categoryOnlyFemale, config.categories.newRecurring],
             columns: [config.categories.targetActual],
             rows: [dimensions.data, dimensions.period],
         });

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -34,6 +34,7 @@ export default class ProjectDashboard {
     dataElements: ProjectsListDashboard["dataElements"];
     merDataElements: Record<"all" | "people" | "benefit", Ref[]>;
     categoryOnlyNew: { id: Id; categoryOptions: Ref[] };
+    categoryOnlyMale: { id: Id; categoryOptions: Ref[] };
 
     constructor(
         private config: Config,
@@ -56,6 +57,11 @@ export default class ProjectDashboard {
         this.categoryOnlyNew = {
             id: config.categories.newRecurring.id,
             categoryOptions: [{ id: config.categoryOptions.new.id }],
+        };
+
+        this.categoryOnlyMale = {
+            id: config.categories.gender.id,
+            categoryOptions: [{ id: config.categoryOptions.male.id }],
         };
 
         this.config = config;
@@ -113,6 +119,10 @@ export default class ProjectDashboard {
             this.dashboardType === "project" ? this.targetVsActualBenefitsLineChart() : undefined;
         const targetVsActualPeopleLineChart_ =
             this.dashboardType === "project" ? this.targetVsActualPeopleLineChart() : undefined;
+        const targetVsActualPeopleLineChartMaleOnly_ =
+            this.dashboardType === "project"
+                ? this.targetVsActualPeopleLineChartMaleOnly()
+                : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -155,6 +165,7 @@ export default class ProjectDashboard {
             targetVsActualPeopleDisaggregatedByIndicatorChart_,
             targetVsActualBenefitsLineChart_,
             targetVsActualPeopleLineChart_,
+            targetVsActualPeopleLineChartMaleOnly_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -185,6 +196,7 @@ export default class ProjectDashboard {
                       getChartDashboardItem(targetVsActualPeopleDisaggregatedByIndicatorChart_),
                       getChartDashboardItem(targetVsActualBenefitsLineChart_),
                       getChartDashboardItem(targetVsActualPeopleLineChart_),
+                      getChartDashboardItem(targetVsActualPeopleLineChartMaleOnly_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -356,6 +368,21 @@ export default class ProjectDashboard {
             name: i18n.t("Target vs Actual - People - Line Chart"),
             items: dataElementItems(dataElements.people),
             filters: [dimensions.orgUnit, config.categories.gender, config.categories.newRecurring],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.data, dimensions.period],
+        });
+    }
+
+    targetVsActualPeopleLineChartMaleOnly(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            chartType: "LINE",
+            key: "chart-target-actual-people-line-male-only",
+            name: i18n.t("Target vs Actual - People - Line Chart - Male Only"),
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, this.categoryOnlyMale, config.categories.newRecurring],
             columns: [config.categories.targetActual],
             rows: [dimensions.data, dimensions.period],
         });

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -83,6 +83,8 @@ export default class ProjectDashboard {
 
         const targetVsActualBenefitsChart_ =
             this.dashboardType === "project" ? this.targetVsActualBenefitsChart() : undefined;
+        const targetVsActualPeopleChart_ =
+            this.dashboardType === "project" ? this.targetVsActualPeopleChart() : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -110,7 +112,7 @@ export default class ProjectDashboard {
         const achievedMonthlyChart_ = this.achievedMonthlyChart();
         const favorites = {
             visualizations: _.concat(
-                _.compact([targetVsActualBenefitsChart_]),
+                _.compact([targetVsActualBenefitsChart_, targetVsActualPeopleChart_]),
                 reportTables,
                 _.compact([achievedMonthlyChart_, ...charts])
             ),
@@ -118,6 +120,7 @@ export default class ProjectDashboard {
 
         const items: Array<PartialModel<D2DashboardItem>> = _.compact([
             getChartDashboardItem(targetVsActualBenefitsChart_),
+            getChartDashboardItem(targetVsActualPeopleChart_),
             ...reportTables.map(reportTable => getReportTableItem(reportTable)),
             getChartDashboardItem(achievedMonthlyChart_, { width: toItemWidth(100) }),
             ...charts.map(chart => getChartDashboardItem(chart)),
@@ -168,6 +171,25 @@ export default class ProjectDashboard {
             name: i18n.t("Target vs Actual - Benefits - Column Chart"),
             items: dataElementItems(dataElementsNoDisaggregated),
             filters: [dimensions.data, dimensions.orgUnit],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.period],
+        });
+    }
+
+    targetVsActualPeopleChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-target-actual-people",
+            name: i18n.t("Target vs Actual - People - Column Chart"),
+            items: dataElementItems(dataElements.people),
+            filters: [
+                dimensions.data,
+                dimensions.orgUnit,
+                config.categories.gender,
+                config.categories.newRecurring,
+            ],
             columns: [config.categories.targetActual],
             rows: [dimensions.period],
         });

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -136,6 +136,10 @@ export default class ProjectDashboard {
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineColumnChartMaleOnly()
                 : undefined;
+        const targetVsActualPeopleLineColumnChartFemaleOnly_ =
+            this.dashboardType === "project"
+                ? this.targetVsActualPeopleLineColumnChartFemaleOnly()
+                : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -181,6 +185,7 @@ export default class ProjectDashboard {
             targetVsActualPeopleLineChartMaleOnly_,
             targetVsActualPeopleLineChartFemaleOnly_,
             targetVsActualPeopleLineColumnChartMaleOnly_,
+            targetVsActualPeopleLineColumnChartFemaleOnly_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -214,6 +219,7 @@ export default class ProjectDashboard {
                       getChartDashboardItem(targetVsActualPeopleLineChartMaleOnly_),
                       getChartDashboardItem(targetVsActualPeopleLineChartFemaleOnly_),
                       getChartDashboardItem(targetVsActualPeopleLineColumnChartMaleOnly_),
+                      getChartDashboardItem(targetVsActualPeopleLineColumnChartFemaleOnly_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -445,6 +451,31 @@ export default class ProjectDashboard {
         });
     }
 
+    targetVsActualPeopleLineColumnChartFemaleOnly(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            chartType: "LINE",
+            key: "chart-target-actual-people-line-column-female-only",
+            name: i18n.t("Target vs Actual - People - Line/Column Chart - Female Only"),
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, this.categoryOnlyFemale, config.categories.newRecurring],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.data, dimensions.period],
+            extra: {
+                series: [
+                    { dimensionItem: config.categoryOptions.target.id, axis: 0 },
+                    {
+                        dimensionItem: config.categoryOptions.actual.id,
+                        axis: 0,
+                        type: "COLUMN",
+                    },
+                ],
+            },
+        });
+    }
+
     targetVsActualBenefitsWithDisaggregationTable(): MaybeD2Visualization {
         const { config, dataElements } = this;
         const dataElementsDisaggregated = dataElements.benefit.filter(de =>
@@ -516,7 +547,7 @@ export default class ProjectDashboard {
         return this.getD2VisualizationFromDefinition({
             type: "table",
             key: "reportTable-indicators-people",
-            name: i18n.t("Achieved (%) - People"),
+            name: i18n.t("Achieved to date (%) - People"),
             items: indicatorItems(indicators),
             filters: [dimensions.orgUnit],
             columns: [dimensions.period],

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -132,6 +132,10 @@ export default class ProjectDashboard {
             this.dashboardType === "project"
                 ? this.targetVsActualPeopleLineChartFemaleOnly()
                 : undefined;
+        const targetVsActualPeopleLineColumnChartMaleOnly_ =
+            this.dashboardType === "project"
+                ? this.targetVsActualPeopleLineColumnChartMaleOnly()
+                : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -176,6 +180,7 @@ export default class ProjectDashboard {
             targetVsActualPeopleLineChart_,
             targetVsActualPeopleLineChartMaleOnly_,
             targetVsActualPeopleLineChartFemaleOnly_,
+            targetVsActualPeopleLineColumnChartMaleOnly_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -208,6 +213,7 @@ export default class ProjectDashboard {
                       getChartDashboardItem(targetVsActualPeopleLineChart_),
                       getChartDashboardItem(targetVsActualPeopleLineChartMaleOnly_),
                       getChartDashboardItem(targetVsActualPeopleLineChartFemaleOnly_),
+                      getChartDashboardItem(targetVsActualPeopleLineColumnChartMaleOnly_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -411,6 +417,31 @@ export default class ProjectDashboard {
             filters: [dimensions.orgUnit, this.categoryOnlyFemale, config.categories.newRecurring],
             columns: [config.categories.targetActual],
             rows: [dimensions.data, dimensions.period],
+        });
+    }
+
+    targetVsActualPeopleLineColumnChartMaleOnly(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            chartType: "LINE",
+            key: "chart-target-actual-people-line-column-male-only",
+            name: i18n.t("Target vs Actual - People - Line/Column Chart - Male Only"),
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, this.categoryOnlyMale, config.categories.newRecurring],
+            columns: [config.categories.targetActual],
+            rows: [dimensions.data, dimensions.period],
+            extra: {
+                series: [
+                    { dimensionItem: config.categoryOptions.target.id, axis: 0 },
+                    {
+                        dimensionItem: config.categoryOptions.actual.id,
+                        axis: 0,
+                        type: "COLUMN",
+                    },
+                ],
+            },
         });
     }
 

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -107,7 +107,6 @@ export default class ProjectDashboard {
             this.targetVsActualBenefitsTable(),
             this.targetVsActualBenefitsWithDisaggregationTable(),
             this.targetVsActualPeopleTable(),
-            this.targetVsActualUniquePeopleTable(),
             // Percent achieved (to date)
             this.achievedBenefitsTable({ toDate: true }),
             this.achievedBenefitsTotalToDateTable(),

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -105,6 +105,10 @@ export default class ProjectDashboard {
             this.dashboardType === "project"
                 ? this.targetVsActualBenefitsDisaggregatedByIndicatorChart()
                 : undefined;
+        const targetVsActualPeopleDisaggregatedByIndicatorChart_ =
+            this.dashboardType === "project"
+                ? this.targetVsActualPeopleDisaggregatedByIndicatorChart()
+                : undefined;
 
         const reportTables: Array<PartialPersistedModel<D2Visualization>> = _.compact([
             // General Data View
@@ -144,6 +148,7 @@ export default class ProjectDashboard {
             targetVsActualBenefitsTable_,
             targetVsActualPeopleTable_,
             targetVsActualBenefitsDisaggregatedByIndicatorChart_,
+            targetVsActualPeopleDisaggregatedByIndicatorChart_,
             targetVsActualBenefitsWithDisaggregationTable_,
         ]);
         const defaultVisualizations = _.concat(
@@ -171,6 +176,7 @@ export default class ProjectDashboard {
                       getReportTableItem(targetVsActualBenefitsTable_),
                       getReportTableItem(targetVsActualPeopleTable_),
                       getChartDashboardItem(targetVsActualBenefitsDisaggregatedByIndicatorChart_),
+                      getChartDashboardItem(targetVsActualPeopleDisaggregatedByIndicatorChart_),
                       getReportTableItem(targetVsActualBenefitsWithDisaggregationTable_),
                   ])
                 : reportTables.map(reportTable => getReportTableItem(reportTable))),
@@ -295,6 +301,20 @@ export default class ProjectDashboard {
             name: i18n.t("Target vs Actual - Benefits - Column Chart Disaggregated By Indicator"),
             items: dataElementItems(dataElementsNoDisaggregated),
             filters: [dimensions.orgUnit],
+            columns: [dimensions.data],
+            rows: [dimensions.period, config.categories.targetActual],
+        });
+    }
+
+    targetVsActualPeopleDisaggregatedByIndicatorChart(): MaybeD2Visualization {
+        const { config, dataElements } = this;
+
+        return this.getD2VisualizationFromDefinition({
+            type: "chart",
+            key: "chart-target-actual-people-disaggregated-by-indicator",
+            name: i18n.t("Target vs Actual - People - Column Chart Disaggregated By Indicator"),
+            items: dataElementItems(dataElements.people),
+            filters: [dimensions.orgUnit, config.categories.gender, config.categories.newRecurring],
             columns: [dimensions.data],
             rows: [dimensions.period, config.categories.targetActual],
         });

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -469,7 +469,8 @@ export default class ProjectDb {
             const dataSetAttrs = { ...dbDataSet, ...attrs, id: dbDataSet.id };
             const res = await this.api.models.dataSets.put(dataSetAttrs).getData();
 
-            if (res.errorReports && res.errorReports.length > 0) throw new Error("Error saving data set");
+            if (res.errorReports && res.errorReports.length > 0)
+                throw new Error("Error saving data set");
         }
     }
 
@@ -586,7 +587,8 @@ export default class ProjectDb {
 
             const res = await api.models.dataSets.put(dataSetUpdated).getData();
 
-            if (res.errorReports && res.errorReports.length > 0) console.error("Error saving data set");
+            if (res.errorReports && res.errorReports.length > 0)
+                console.error("Error saving data set");
         }
     }
 

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -469,7 +469,7 @@ export default class ProjectDb {
             const dataSetAttrs = { ...dbDataSet, ...attrs, id: dbDataSet.id };
             const res = await this.api.models.dataSets.put(dataSetAttrs).getData();
 
-            if (res.status !== "OK") throw new Error("Error saving data set");
+            if (res.errorReports && res.errorReports.length > 0) throw new Error("Error saving data set");
         }
     }
 
@@ -586,7 +586,7 @@ export default class ProjectDb {
 
             const res = await api.models.dataSets.put(dataSetUpdated).getData();
 
-            if (res.status !== "OK") console.error("Error saving data set");
+            if (res.errorReports && res.errorReports.length > 0) console.error("Error saving data set");
         }
     }
 
@@ -663,7 +663,7 @@ export default class ProjectDb {
             sections: sections.map(section => ({ id: section.id, code: section.code })),
             dataSetElements,
             code: `${orgUnit.id}_${baseDataSet.code}`,
-            ...projectSharing.getSharingAttributesForDataSets(),
+            sharing: projectSharing.getSharingAttributesForDataSets(),
         };
 
         return { dataSets: [dataSet], sections };
@@ -1244,8 +1244,6 @@ export const dataSetFields = {
     sections: { code: true, dataElements: { id: true } },
     openFuturePeriods: true,
     expiryDays: true,
-    publicAccess: true,
-    externalAccess: true,
-    userAccesses: { id: true, displayName: true, access: true },
-    userGroupAccesses: { id: true, displayName: true, access: true },
+    sharing: { public: true, external: true, users: true, userGroups: true },
+    access: { read: true, write: true, data: true },
 } as const;

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -37,6 +37,7 @@ import { DashboardSourceMetadata } from "./ProjectsListDashboard";
 import { promiseMap } from "../migrations/utils";
 import { ProjectDocument } from "./ProjectDocument";
 import { ProjectDocumentRepository } from "./ProjectDocumentRepository";
+import { DataSetCustomForm } from "../data/DataSetCustomForm";
 
 const expiryDaysInMonthActual = 10;
 
@@ -313,6 +314,7 @@ export default class ProjectDb {
             workflow: { id: config.dataApprovalWorkflows.project.id },
             ...this.getDataSetOpenAttributes("actual"),
         });
+
         const dataSetActual = _(dataSetActualMetadata.dataSets).getOrFail(0);
 
         const projectMetadata = this.getProjectMetadataForDashboard(orgUnit, dataSetActual);
@@ -393,7 +395,19 @@ export default class ProjectDb {
 
         await this.updateOrgUnit(response, orgUnit);
 
+        if (response && response.status === "OK") {
+            await this.saveCustomForms(savedProject);
+        }
+
         return { payload, response, project: savedProject };
+    }
+
+    private async saveCustomForms(savedProject: Project) {
+        const dataSets = savedProject.dataSets;
+        if (!dataSets) return;
+        const customForm = new DataSetCustomForm(this.api);
+        await customForm.saveCustomForm(dataSets.actual.id, savedProject, "actual");
+        await customForm.saveCustomForm(dataSets.target.id, savedProject, "target");
     }
 
     getProjectMetadataForDashboard(
@@ -626,7 +640,7 @@ export default class ProjectDb {
         baseDataSet: PartialModel<D2DataSet> & Pick<D2DataSet, "code" | OpenProperties>
     ) {
         const { config, project } = this;
-        const dataSetId = getUid("dataSet", project.uid + baseDataSet.code);
+        const dataSetId = this.getDataSetId(project.uid, baseDataSet.code);
         const selectedDataElements = project.getSelectedDataElements();
 
         const dataSetElements = _.uniqBy(selectedDataElements, de => de.id).map(dataElement => ({
@@ -669,6 +683,11 @@ export default class ProjectDb {
         };
 
         return { dataSets: [dataSet], sections };
+    }
+
+    private getDataSetId(projectId: Id, dataSetCode: string) {
+        const dataSetId = getUid("dataSet", projectId + dataSetCode);
+        return dataSetId;
     }
 
     static getCodeInfo(code: string) {

--- a/src/models/ProjectNotification.ts
+++ b/src/models/ProjectNotification.ts
@@ -26,14 +26,14 @@ export class ProjectNotification {
         const { users: usersInGroup } = await api.metadata
             .get({
                 users: {
-                    fields: { email: true, userCredentials: { disabled: true } },
+                    fields: { email: true, disabled: true },
                     filter: { "userGroups.code": { eq: groupCode } },
                 },
             })
             .getData();
 
         const users = _(usersInGroup)
-            .reject(user => user.userCredentials.disabled)
+            .reject(user => user.disabled)
             .value();
 
         return _(appConfig.app.notifyEmailOnProjectSave)
@@ -63,7 +63,7 @@ export class ProjectNotification {
                         users: {
                             email: true,
                             id: true,
-                            userCredentials: { disabled: true },
+                            disabled: true,
                             userGroups: {
                                 id: true,
                                 name: true,
@@ -75,11 +75,7 @@ export class ProjectNotification {
                 dataSets: {
                     fields: {
                         id: true,
-                        userGroupAccesses: {
-                            id: true,
-                            displayName: true,
-                        },
-                        userAccesses: { id: true },
+                        sharing: { public: true, external: true, users: true, userGroups: true },
                     },
                     filter: { id: { in: [id] } },
                 },
@@ -104,20 +100,21 @@ export class ProjectNotification {
 
         const users = _(res.userRoles)
             .flatMap(userRole => userRole.users)
-            .reject(user => user.userCredentials.disabled)
+            .reject(user => user.disabled)
             .value();
+
+        const sharingUsers = dataSet.sharing.users || {};
+        const sharingUserGroups = dataSet.sharing.userGroups || {};
 
         const userAccessEmails = users
             .filter(user => {
-                return dataSet.userAccesses.some(userAccess => {
-                    return userAccess.id === user.id;
-                });
+                return sharingUsers[user.id] !== undefined;
             })
             .map(user => user.email);
 
         const userGroupEmails = users
             .filter(user => {
-                return dataSet.userGroupAccesses
+                return Object.values(sharingUserGroups)
                     .filter(ug => ug.displayName.includes("Country Admin"))
                     .some(userGroupAccess => {
                         return user.userGroups.some(userGroup => {

--- a/src/models/ProjectSharing.ts
+++ b/src/models/ProjectSharing.ts
@@ -1,7 +1,7 @@
 import { OrganisationUnit } from "./Project";
 import _ from "lodash";
 import { Config } from "./Config";
-import { D2DataSetSchema, Ref } from "../types/d2-api";
+import { Ref } from "../types/d2-api";
 import {
     Sharing,
     EntityAccess,
@@ -26,6 +26,7 @@ export default class ProjectSharing {
     constructor(private config: Config, public project: ProjectForSharing) {}
 
     static getInitialSharing(config: Config): Sharing {
+        console.log("config", config);
         const { currentUser, userGroups } = config;
         const userAccesses: EntityAccess[] = [
             { id: currentUser.id, name: currentUser.displayName },

--- a/src/models/ProjectSharing.ts
+++ b/src/models/ProjectSharing.ts
@@ -95,10 +95,7 @@ export default class ProjectSharing {
                     public: "--------",
                     external: false,
                     users: getD2SharingMap(project.sharing.userAccesses, fullAccess),
-                    userGroups: getD2SharingMap(
-                        project.sharing.userGroupAccesses,
-                        fullAccess
-                    ),
+                    userGroups: getD2SharingMap(project.sharing.userGroupAccesses, fullAccess),
                 },
             },
         };
@@ -157,7 +154,9 @@ interface D2DataSetAccessFields {
     data?: { read: boolean; write: boolean };
 }
 
-export function hasCurrentUserFullAccessToDataSet(shareable: { access: D2DataSetAccessFields }): boolean {
+export function hasCurrentUserFullAccessToDataSet(shareable: {
+    access: D2DataSetAccessFields;
+}): boolean {
     const { access } = shareable;
     const metadataAccess = access.read && access.write;
     const dataAccess = access.data ? access.data.read && access.data.write : true;

--- a/src/models/ProjectSharing.ts
+++ b/src/models/ProjectSharing.ts
@@ -8,7 +8,7 @@ import {
     D2SharingUpdate,
     mergeSharing,
     D2Sharing,
-    getD2EntitiesAccess,
+    getD2SharingMap,
     fullAccess,
     fullMetadataAccess,
     getEntitiesAccess,
@@ -63,10 +63,10 @@ export default class ProjectSharing {
         const { userAccesses, userGroupAccesses } = this.project.sharing;
 
         return {
-            publicAccess: "--------",
-            externalAccess: false,
-            userAccesses: getD2EntitiesAccess(userAccesses, fullAccess),
-            userGroupAccesses: getD2EntitiesAccess(userGroupAccesses, fullAccess),
+            public: "--------",
+            external: false,
+            users: getD2SharingMap(userAccesses, fullAccess),
+            userGroups: getD2SharingMap(userGroupAccesses, fullAccess),
         };
     }
 
@@ -74,10 +74,10 @@ export default class ProjectSharing {
         const { userAccesses, userGroupAccesses } = this.project.sharing;
 
         return {
-            publicAccess: "--------",
-            externalAccess: false,
-            userAccesses: getD2EntitiesAccess(userAccesses, fullMetadataAccess),
-            userGroupAccesses: getD2EntitiesAccess(userGroupAccesses, fullMetadataAccess),
+            public: "--------",
+            external: false,
+            users: getD2SharingMap(userAccesses, fullMetadataAccess),
+            userGroups: getD2SharingMap(userGroupAccesses, fullMetadataAccess),
         };
     }
 
@@ -91,13 +91,15 @@ export default class ProjectSharing {
             },
             object: {
                 id: project.id,
-                publicAccess: "--------",
-                externalAccess: false,
-                userAccesses: getD2EntitiesAccess(project.sharing.userAccesses, fullAccess),
-                userGroupAccesses: getD2EntitiesAccess(
-                    project.sharing.userGroupAccesses,
-                    fullAccess
-                ),
+                sharing: {
+                    public: "--------",
+                    external: false,
+                    users: getD2SharingMap(project.sharing.userAccesses, fullAccess),
+                    userGroups: getD2SharingMap(
+                        project.sharing.userGroupAccesses,
+                        fullAccess
+                    ),
+                },
             },
         };
     }
@@ -149,11 +151,13 @@ export default class ProjectSharing {
     }
 }
 
-type D2DataSetAccess = D2DataSetSchema["fields"]["access"] & {
-    data?: { read: boolean; write: boolean }; // Currently not in d2-api, add manually
-};
+interface D2DataSetAccessFields {
+    read: boolean;
+    write: boolean;
+    data?: { read: boolean; write: boolean };
+}
 
-export function hasCurrentUserFullAccessToDataSet(shareable: { access: D2DataSetAccess }): boolean {
+export function hasCurrentUserFullAccessToDataSet(shareable: { access: D2DataSetAccessFields }): boolean {
     const { access } = shareable;
     const metadataAccess = access.read && access.write;
     const dataAccess = access.data ? access.data.read && access.data.write : true;

--- a/src/models/ProjectsList.ts
+++ b/src/models/ProjectsList.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { TableSorting } from "@eyeseetea/d2-ui-components";
 import { D2Api, D2OrganisationUnitSchema, SelectedPick, Id, Pager, Ref } from "../types/d2-api";
 import { Config } from "./Config";
 import moment, { Moment } from "moment";
@@ -399,3 +398,8 @@ function getOrgUnitsFilter(filters: FiltersForList, currentUser: User) {
         : userCountryIds;
     return filterCountryIds ? { "parent.id": { in: filterCountryIds } } : {};
 }
+
+export type TableSorting<T> = {
+    field: keyof T;
+    order: "asc" | "desc";
+};

--- a/src/models/ProjectsList.ts
+++ b/src/models/ProjectsList.ts
@@ -103,7 +103,12 @@ export default class ProjectsList {
                           fields: {
                               code: true,
                               sections: { code: true },
-                              sharing: { public: true, external: true, users: true, userGroups: true },
+                              sharing: {
+                                  public: true,
+                                  external: true,
+                                  users: true,
+                                  userGroups: true,
+                              },
                               access: { read: true, write: true, data: true },
                               attributeValues: { attribute: { id: true }, value: true },
                           },

--- a/src/models/ProjectsList.ts
+++ b/src/models/ProjectsList.ts
@@ -103,9 +103,8 @@ export default class ProjectsList {
                           fields: {
                               code: true,
                               sections: { code: true },
-                              userAccesses: { id: true, displayName: true, access: true },
-                              userGroupAccesses: { id: true, displayName: true, access: true },
-                              access: true,
+                              sharing: { public: true, external: true, users: true, userGroups: true },
+                              access: { read: true, write: true, data: true },
                               attributeValues: { attribute: { id: true }, value: true },
                           },
                           // When there are many projects, this results in a 414 error, filter on the response.

--- a/src/models/ProjectsListDashboard.ts
+++ b/src/models/ProjectsListDashboard.ts
@@ -60,10 +60,7 @@ const query = {
         id: true,
         code: true,
         dataInputPeriods: { period: { id: true } },
-        publicAccess: true,
-        externalAccess: true,
-        userAccesses: { id: true, access: true, displayName: true },
-        userGroupAccesses: { id: true, access: true, displayName: true },
+        sharing: { public: true, external: true, users: true, userGroups: true },
         dataSetElements: {
             dataElement: {
                 id: true,
@@ -189,13 +186,14 @@ async function getMetadata(api: D2Api, condition: Condition): Promise<DashboardS
     return {
         orgUnits,
         dataSets: dataSets.map(d2DataSet => {
+            // TODO: Further research on "ghosts users"
+            // there're some references to non-existing users in some dataSets
+            // sharing.users may contain ids of users that don't exist but without displayName.
+            // As a temporal fix we're filtering out those users.
+            const filteredUsers = _.pickBy(d2DataSet.sharing.users, user => user.displayName);
             return {
                 ...d2DataSet,
-                // TODO: Further research on "ghosts users"
-                // there're some references to non-existing users in some dataSets
-                // userAccesses is returning ids of users that don't exist but without displayName.
-                // As a temporal fix we're filtering out those users.
-                userAccesses: d2DataSet.userAccesses.filter(userAccess => userAccess.displayName),
+                sharing: { ...d2DataSet.sharing, users: filteredUsers },
             };
         }),
     };

--- a/src/models/Sharing.ts
+++ b/src/models/Sharing.ts
@@ -2,20 +2,25 @@ import _ from "lodash";
 
 export type D2Access = string;
 
-export interface D2Sharing {
-    publicAccess: D2Access;
-    externalAccess: boolean;
-    userAccesses: D2EntityAccess[];
-    userGroupAccesses: D2EntityAccess[];
-}
-
-export type D2SharingUpdate = Partial<D2Sharing>;
-
 export interface D2EntityAccess {
     access: D2Access;
     displayName: string;
     id: string;
 }
+
+export type D2SharingMap = Record<string, D2EntityAccess>;
+
+export interface D2Sharing {
+    public: D2Access;
+    external: boolean;
+    users: D2SharingMap;
+    userGroups: D2SharingMap;
+}
+
+export type D2SharingUpdate = Partial<{
+    userAccesses: D2EntityAccess[];
+    userGroupAccesses: D2EntityAccess[];
+}>;
 
 export interface Sharing {
     userAccesses: EntityAccess[];
@@ -46,15 +51,19 @@ export const emptySharing: Sharing = {
     userGroupAccesses: [],
 };
 
-export function getD2EntitiesAccess(
+export function getD2SharingMap(
     entitySharings: EntityAccess[],
     access: Access
-): D2EntityAccess[] {
-    return entitySharings.map(entitySharing => ({
-        id: entitySharing.id,
-        displayName: entitySharing.name,
-        access: getD2Access(access),
-    }));
+): D2SharingMap {
+    const result: D2SharingMap = {};
+    entitySharings.forEach(entitySharing => {
+        result[entitySharing.id] = {
+            id: entitySharing.id,
+            displayName: entitySharing.name,
+            access: getD2Access(access),
+        };
+    });
+    return result;
 }
 
 export function getD2Access(d2Access: Access): D2Access {
@@ -74,9 +83,17 @@ export function getEntitiesAccess(d2EntitySharings: D2EntityAccess[]): EntityAcc
     }));
 }
 
-export function getSharing(object: Partial<D2Sharing>): Sharing {
-    const userAccesses = getEntitiesAccess(object.userAccesses || []);
-    const userGroupAccesses = getEntitiesAccess(object.userGroupAccesses || []);
+export function getEntitiesAccessFromMap(d2SharingMap: D2SharingMap): EntityAccess[] {
+    return Object.values(d2SharingMap).map(ref => ({
+        id: ref.id,
+        name: ref.displayName,
+    }));
+}
+
+export function getSharing(object: { sharing?: Partial<D2Sharing> }): Sharing {
+    const sharing = object.sharing || {};
+    const userAccesses = getEntitiesAccessFromMap(sharing.users || {});
+    const userGroupAccesses = getEntitiesAccessFromMap(sharing.userGroups || {});
     return { userAccesses, userGroupAccesses };
 }
 

--- a/src/models/Sharing.ts
+++ b/src/models/Sharing.ts
@@ -51,10 +51,7 @@ export const emptySharing: Sharing = {
     userGroupAccesses: [],
 };
 
-export function getD2SharingMap(
-    entitySharings: EntityAccess[],
-    access: Access
-): D2SharingMap {
+export function getD2SharingMap(entitySharings: EntityAccess[], access: Access): D2SharingMap {
     const result: D2SharingMap = {};
     entitySharings.forEach(entitySharing => {
         result[entitySharing.id] = {

--- a/src/models/__tests__/Project.spec.ts
+++ b/src/models/__tests__/Project.spec.ts
@@ -442,7 +442,7 @@ describe("Project", () => {
             mock.onGet("/metadata", {
                 params: {
                     "dataSets:fields":
-                        "access,attributeValues[attribute[id],value],code,sections[code],userAccesses[access,displayName,id],userGroupAccesses[access,displayName,id]",
+                        "access[data,read,write],attributeValues[attribute[id],value],code,sections[code],sharing[external,public,userGroups,users]",
                     "dataSets:filter": ["code:like$:_ACTUAL"],
                     "organisationUnitGroupSets:fields":
                         "id,organisationUnitGroups[id,organisationUnits[id]]",
@@ -457,6 +457,7 @@ describe("Project", () => {
                             { code: "SECTOR_AGRICULTURE_ds3", dataElements: [{ id: "de1" }] },
                         ],
                         access: fullAccess,
+                        sharing: { public: "--------", external: false, users: {}, userGroups: {} },
                         attributeValues: [],
                     },
                     {
@@ -466,6 +467,7 @@ describe("Project", () => {
                             { code: "SECTOR_AGRICULTURE_ds5", dataElements: [{ id: "de2" }] },
                         ],
                         access: metadataAccess,
+                        sharing: { public: "--------", external: false, users: {}, userGroups: {} },
                         attributeValues: [],
                     },
                 ],
@@ -564,10 +566,8 @@ const metadataForGet = {
         {
             code: "R3rGhxWbAI9_ACTUAL",
             id: "imYbEtdoQZx",
-            publicAccess: "--------",
-            externalAccess: false,
-            userAccesses: [],
-            userGroupAccesses: [],
+            sharing: { public: "--------", external: false, users: {}, userGroups: {} },
+            access: { read: true, write: true, data: { read: true, write: true } },
             dataSetElements: [
                 {
                     categoryCombo: {
@@ -619,10 +619,8 @@ const metadataForGet = {
         {
             code: "R3rGhxWbAI9_TARGET",
             id: "KC6gi00Jm6H",
-            publicAccess: "--------",
-            externalAccess: false,
-            userAccesses: [],
-            userGroupAccesses: [],
+            sharing: { public: "--------", external: false, users: {}, userGroups: {} },
+            access: { read: true, write: true, data: { read: true, write: true } },
             dataSetElements: [
                 {
                     categoryCombo: {
@@ -683,7 +681,7 @@ async function getProject(): Promise<Project> {
                 "attributeValues[attribute[id],value],closedDate,code,created,description,displayName,id,name,openingDate,organisationUnitGroups[attributeValues[attribute[id],value],groupSets[id],id,name],parent[attributeValues[attribute[id],value],displayName,id,name,path],path",
             "organisationUnits:filter": ["id:eq:R3rGhxWbAI9"],
             "dataSets:fields":
-                "code,dataInputPeriods[closingDate,openingDate,period],dataSetElements[categoryCombo[categoryOptionCombos[id],id],dataElement[id]],expiryDays,externalAccess,id,openFuturePeriods,publicAccess,sections[code,dataElements[id]],userAccesses[access,displayName,id],userGroupAccesses[access,displayName,id]",
+                "access[data,read,write],code,dataInputPeriods[closingDate,openingDate,period],dataSetElements[categoryCombo[categoryOptionCombos[id],id],dataElement[id]],expiryDays,id,openFuturePeriods,sections[code,dataElements[id]],sharing[external,public,userGroups,users]",
             "dataSets:filter": ["code:$like:R3rGhxWbAI9"],
         },
     }).replyOnce(200, metadataForGet);

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -143,7 +143,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,uYWdSMZQ1LH,i07AWJAND8a,iqqgnCj9DQj,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,OuKm5zK7l53,iOk52Z42bjp,GM6SxObVwI3,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,uYWdSMZQ1LH,i07AWJAND8a,iqqgnCj9DQj,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,OuKm5zK7l53,iOk52Z42bjp,GM6SxObVwI3,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,CAEdMM5XM5T,GiUz1pZI2Rq,uwoFl2upiOM,ui6nUS98GBM,mUCwcWSsa9T,ew6e1j5HwkE,OS2K2s8VIIq,uqMTlezGj0I,i8TrzIkXGrG,aGYruOfBtaD,KoIzyX81ZVL,WikhmLU9agJ,yamOXKh6Vok,yaQ772dtmLb]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -12,6 +12,7 @@ const { api, mock } = getMockApi();
 const metadataResponse = {
     status: "OK",
     stats: { created: 0, updated: 0, deleted: 0, ignored: 0, total: 0 },
+    typeReports: [],
 };
 
 const dataStoreUpdateResponse = {
@@ -54,7 +55,7 @@ describe("ProjectDb", () => {
                     "organisationUnits:fields": "children[id,name,parent],id,name,parent",
                     "organisationUnits:filter": ["id:eq:WGC0DJ0YSis"],
                     "dataSets:fields":
-                        "code,dataInputPeriods[period[id]],dataSetElements[dataElement[attributeValues[attribute[id],value],code,dataElementGroups[code],id,name]],externalAccess,id,publicAccess,userAccesses[access,displayName,id],userGroupAccesses[access,displayName,id]",
+                        "code,dataInputPeriods[period[id]],dataSetElements[dataElement[attributeValues[attribute[id],value],code,dataElementGroups[code],id,name]],id,sharing[external,public,userGroups,users]",
                     "dataSets:filter": [
                         "code:like$:_ACTUAL",
                         "organisationUnits.path:like:WGC0DJ0YSis",
@@ -69,7 +70,7 @@ describe("ProjectDb", () => {
                     "organisationUnits:fields": "children[id,name,parent],id,name,parent",
                     "organisationUnits:filter": ["id:eq:eu2XF73JOzl"],
                     "dataSets:fields":
-                        "code,dataInputPeriods[period[id]],dataSetElements[dataElement[attributeValues[attribute[id],value],code,dataElementGroups[code],id,name]],externalAccess,id,publicAccess,userAccesses[access,displayName,id],userGroupAccesses[access,displayName,id]",
+                        "code,dataInputPeriods[period[id]],dataSetElements[dataElement[attributeValues[attribute[id],value],code,dataElementGroups[code],id,name]],id,sharing[external,public,userGroups,users]",
                     "dataSets:filter": [
                         "code:like$:_ACTUAL",
                         "organisationUnits.path:like:eu2XF73JOzl",
@@ -84,7 +85,7 @@ describe("ProjectDb", () => {
                     "organisationUnits:fields": "children[id,name,parent],id,name,parent",
                     "organisationUnits:filter": ["code:$like:12345"],
                     "dataSets:fields":
-                        "code,dataInputPeriods[period[id]],dataSetElements[dataElement[attributeValues[attribute[id],value],code,dataElementGroups[code],id,name]],externalAccess,id,publicAccess,userAccesses[access,displayName,id],userGroupAccesses[access,displayName,id]",
+                        "code,dataInputPeriods[period[id]],dataSetElements[dataElement[attributeValues[attribute[id],value],code,dataElementGroups[code],id,name]],id,sharing[external,public,userGroups,users]",
                     "dataSets:filter": ["code:like$:_ACTUAL", "organisationUnits.code:$like:12345"],
                 },
             }).replyOnce(200, awardNumberMetadataResponse);

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,OuKm5zK7l53,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -21,7 +21,10 @@ const dataStoreUpdateResponse = {
 describe("ProjectDb", () => {
     describe("save", () => {
         it("posts metadata", async () => {
-            const project = await getProject(api, { orgUnit: undefined });
+            const project = (await getProject(api, { orgUnit: undefined })).updateDataElementsMERSelection(
+                "ieyBABjYyHO",
+                ["ik0ICagvIjm"]
+            ).project;
 
             // Validation
             mock.onGet("/metadata", {
@@ -140,7 +143,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,OuKm5zK7l53,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,uYWdSMZQ1LH,i07AWJAND8a,iqqgnCj9DQj,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,GkoTRBEmIQt,S2kJHgM41El,KasxZ8vT1n0,W2SCFrHCiEm,OuKm5zK7l53,iOk52Z42bjp,GM6SxObVwI3,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});
@@ -226,7 +229,7 @@ const orgUnitsMetadata = {
 };
 
 const expectedDataStoreMer = {
-    merDataElementIds: ["yMqK9DKbA3X"],
+    merDataElementIds: ["ik0ICagvIjm", "yMqK9DKbA3X"],
     documents: [],
     uniqueBeneficiaries: { periods: [], indicatorsIds: [] },
 };

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,GA87u7JwgSK,KiUTxsMMYde,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -140,7 +140,7 @@ describe("ProjectDb", () => {
 
             mock.onGet("/metadata", {
                 params: {
-                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
+                    filter: "id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,ywQZlYBN4nN,q0Arl96SxH5,yWq2ZBWiK8T,i07AWJAND8a,iOk52Z42bjp,a46jcQ65Axt,iqqgnCj9DQj,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,KOiGcdA4JjD,CS7csnUtibF,GqYJDh6asM8,me6p7L8VHXl,uqMTlezGj0I,OS2K2s8VIIq,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]",
                     fields: "id,created",
                 },
             }).replyOnce(200, {});

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -21,10 +21,9 @@ const dataStoreUpdateResponse = {
 describe("ProjectDb", () => {
     describe("save", () => {
         it("posts metadata", async () => {
-            const project = (await getProject(api, { orgUnit: undefined })).updateDataElementsMERSelection(
-                "ieyBABjYyHO",
-                ["ik0ICagvIjm"]
-            ).project;
+            const project = (
+                await getProject(api, { orgUnit: undefined })
+            ).updateDataElementsMERSelection("ieyBABjYyHO", ["ik0ICagvIjm"]).project;
 
             // Validation
             mock.onGet("/metadata", {

--- a/src/models/__tests__/data/awardNumber-metadata.json
+++ b/src/models/__tests__/data/awardNumber-metadata.json
@@ -15,27 +15,6 @@
         {
             "code": "cqZ9zQfePzQ_ACTUAL",
             "id": "yAOSOqcfHsi",
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rwrw----"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rwrw----"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rwrw----"
-                }
-            ],
             "dataSetElements": [
                 {
                     "dataElement": {
@@ -193,7 +172,30 @@
                     "closingDate": "2020-10-01T00:00:00.000",
                     "openingDate": "2020-07-01T00:00:00.000"
                 }
-            ]
+            ],
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rwrw----"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rwrw----"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rwrw----"
+                    }
+                }
+            }
         },
         {
             "code": "TvSmIyYcRnd_ACTUAL",
@@ -408,7 +410,12 @@
                     "openingDate": "2020-09-01T00:00:00.000"
                 }
             ],
-            "userAccesses": []
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {},
+                "userGroups": {}
+            }
         }
     ]
 }

--- a/src/models/__tests__/data/country-metadata.json
+++ b/src/models/__tests__/data/country-metadata.json
@@ -20,27 +20,6 @@
         {
             "code": "cqZ9zQfePzQ_ACTUAL",
             "id": "yAOSOqcfHsi",
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rwrw----"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rwrw----"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rwrw----"
-                }
-            ],
             "dataSetElements": [
                 {
                     "dataElement": {
@@ -198,7 +177,30 @@
                     "closingDate": "2020-10-01T00:00:00.000",
                     "openingDate": "2020-07-01T00:00:00.000"
                 }
-            ]
+            ],
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rwrw----"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rwrw----"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rwrw----"
+                    }
+                }
+            }
         },
         {
             "code": "TvSmIyYcRnd_ACTUAL",
@@ -413,7 +415,12 @@
                     "openingDate": "2020-09-01T00:00:00.000"
                 }
             ],
-            "userAccesses": []
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {},
+                "userGroups": {}
+            }
         }
     ]
 }

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1073,6 +1073,17 @@
                     "y": 60
                 },
                 {
+                    "id": "KYcDaXAZa1q",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "KiUTxsMMYde"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 60
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1080,8 +1091,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 60
+                    "x": 0,
+                    "y": 80
                 },
                 {
                     "id": "ywvTGMsKdwL",
@@ -1091,7 +1102,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 80
                 },
                 {
@@ -1102,8 +1113,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 80
+                    "x": 0,
+                    "y": 100
                 },
                 {
                     "id": "uyoJujQVRjE",
@@ -1113,7 +1124,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 100
                 },
                 {
@@ -1124,8 +1135,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 100
+                    "x": 0,
+                    "y": 120
                 },
                 {
                     "id": "ys0CVedHirZ",
@@ -1136,7 +1147,7 @@
                     "width": 58,
                     "height": 20,
                     "x": 0,
-                    "y": 120
+                    "y": 140
                 },
                 {
                     "id": "KI0C90Ol10x",
@@ -1147,7 +1158,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 140
+                    "y": 160
                 },
                 {
                     "id": "uYY7v977Ubm",
@@ -1158,7 +1169,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 140
+                    "y": 160
                 },
                 {
                     "id": "qUqsDmtiBLF",
@@ -1169,7 +1180,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 160
+                    "y": 180
                 },
                 {
                     "id": "mwMpIdPdu8H",
@@ -1180,7 +1191,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 160
+                    "y": 180
                 }
             ],
             "publicAccess": "--------",
@@ -2386,6 +2397,135 @@
                         },
                         {
                             "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "KiUTxsMMYde",
+            "type": "LINE",
+            "name": "12345en - MyProject - Target vs Actual - Benefits - Line Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WS8XV4WWPE7"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": [
+                "ou"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
                         }
                     ]
                 }

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1007,6 +1007,17 @@
                     "y": 0
                 },
                 {
+                    "id": "mouU4wUzbJ3",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "q0Arl96SxH5"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 0
+                },
+                {
                     "id": "Ka4yijY2Vhl",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1014,8 +1025,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 0
+                    "x": 0,
+                    "y": 20
                 },
                 {
                     "id": "yWGKgz9vaOh",
@@ -1025,7 +1036,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 20
                 },
                 {
@@ -1036,8 +1047,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 20
+                    "x": 0,
+                    "y": 40
                 },
                 {
                     "id": "m4LaU9HizHi",
@@ -1047,7 +1058,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 40
                 },
                 {
@@ -1058,8 +1069,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 40
+                    "x": 0,
+                    "y": 60
                 },
                 {
                     "id": "qMSWdZHPjyN",
@@ -1069,7 +1080,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 60
                 },
                 {
@@ -1080,8 +1091,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 60
+                    "x": 0,
+                    "y": 80
                 },
                 {
                     "id": "mgwFIMjbsdw",
@@ -1091,7 +1102,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 80
                 },
                 {
@@ -1491,6 +1502,190 @@
                         },
                         {
                             "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "q0Arl96SxH5",
+            "type": "COLUMN",
+            "name": "12345en - MyProject - Target vs Actual - People - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
+            "filters": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "ou"
+                },
+                {
+                    "code": "GENDER",
+                    "id": "Kyg1O6YEGa9",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "MALE",
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "code": "FEMALE",
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "rows": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": ["pe"],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
                         }
                     ]
                 }

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1294,10 +1294,10 @@
             "name": "Award Number 12345",
             "dashboardItems": [
                 {
-                    "id": "W4EN8esNyGQ",
+                    "id": "CSL3EN6eJwx",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "uqMTlezGj0I"
+                        "id": "CAEdMM5XM5T"
                     },
                     "width": 29,
                     "height": 20,
@@ -1305,10 +1305,10 @@
                     "y": 0
                 },
                 {
-                    "id": "GCm9PNnLAgP",
-                    "type": "REPORT_TABLE",
+                    "id": "iYkPSnM7m4E",
+                    "type": "CHART",
                     "visualization": {
-                        "id": "OS2K2s8VIIq"
+                        "id": "GiUz1pZI2Rq"
                     },
                     "width": 29,
                     "height": 20,
@@ -1316,14 +1316,25 @@
                     "y": 0
                 },
                 {
-                    "id": "O0uabsxLqGS",
+                    "id": "yI8WlxGRfXU",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "ew6e1j5HwkE"
+                        "id": "uwoFl2upiOM"
                     },
                     "width": 29,
                     "height": 20,
                     "x": 0,
+                    "y": 20
+                },
+                {
+                    "id": "aCiqCXWYZ9P",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "ui6nUS98GBM"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
                     "y": 20
                 },
                 {
@@ -1334,25 +1345,14 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 20
-                },
-                {
-                    "id": "iIyADNFfXEV",
-                    "type": "REPORT_TABLE",
-                    "visualization": {
-                        "id": "KeWVSa2rbYm"
-                    },
-                    "width": 29,
-                    "height": 20,
                     "x": 0,
                     "y": 40
                 },
                 {
-                    "id": "eU2Bs4XsX6J",
+                    "id": "O0uabsxLqGS",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "i6CWRJp61Hp"
+                        "id": "ew6e1j5HwkE"
                     },
                     "width": 29,
                     "height": 20,
@@ -1360,10 +1360,10 @@
                     "y": 40
                 },
                 {
-                    "id": "yseGHIbXcNQ",
+                    "id": "GCm9PNnLAgP",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "eYaYrZfbJT1"
+                        "id": "OS2K2s8VIIq"
                     },
                     "width": 29,
                     "height": 20,
@@ -1371,10 +1371,10 @@
                     "y": 60
                 },
                 {
-                    "id": "GqqyIiwIxog",
-                    "type": "CHART",
+                    "id": "W4EN8esNyGQ",
+                    "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "Gi2PegQJhbu"
+                        "id": "uqMTlezGj0I"
                     },
                     "width": 29,
                     "height": 20,
@@ -1382,10 +1382,10 @@
                     "y": 60
                 },
                 {
-                    "id": "mCeCHYX6DOG",
-                    "type": "CHART",
+                    "id": "OuQLaEe9G9v",
+                    "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "Ww2X5s48uQx"
+                        "id": "i8TrzIkXGrG"
                     },
                     "width": 29,
                     "height": 20,
@@ -1393,10 +1393,10 @@
                     "y": 80
                 },
                 {
-                    "id": "O8EPBVIg4zK",
-                    "type": "CHART",
+                    "id": "i60k7CBbyJZ",
+                    "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "CMqisHj7sP9"
+                        "id": "aGYruOfBtaD"
                     },
                     "width": 29,
                     "height": 20,
@@ -1404,15 +1404,48 @@
                     "y": 80
                 },
                 {
-                    "id": "OI8TXjJJwfS",
-                    "type": "CHART",
+                    "id": "qeWaohT6Mgt",
+                    "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "WGWGaYtwJzp"
+                        "id": "KoIzyX81ZVL"
                     },
                     "width": 29,
                     "height": 20,
                     "x": 0,
                     "y": 100
+                },
+                {
+                    "id": "y84WQGCtWxT",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "WikhmLU9agJ"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 100
+                },
+                {
+                    "id": "eCWMTNjreWb",
+                    "type": "REPORT_TABLE",
+                    "visualization": {
+                        "id": "yamOXKh6Vok"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 120
+                },
+                {
+                    "id": "eUcnQVKRn34",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "yaQ772dtmLb"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 120
                 }
             ],
             "publicAccess": "--------",
@@ -5027,9 +5060,456 @@
             "publicAccess": "rw------"
         },
         {
-            "id": "uqMTlezGj0I",
+            "id": "CAEdMM5XM5T",
             "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Target vs Actual - Benefits",
+            "name": "Award Number 12345 - Target vs Actual - People - Pivot Table",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": [
+                "ou"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "GiUz1pZI2Rq",
+            "type": "COLUMN",
+            "name": "Award Number 12345 - Target vs Actual - People - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "dx"
+                }
+            ],
+            "columnDimensions": [
+                "dx"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "code": "GENDER",
+                    "id": "Kyg1O6YEGa9",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "MALE",
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "code": "FEMALE",
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "GIIHAr9BzzO",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "uwoFl2upiOM",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Target vs Actual - Benefits - Pivot Table",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -5086,6 +5566,570 @@
                     "dataDimensionItemType": "DATA_ELEMENT",
                     "dataElement": {
                         "id": "yMqK9DKbA3X"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": [
+                "ou"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "ui6nUS98GBM",
+            "type": "COLUMN",
+            "name": "Award Number 12345 - Target vs Actual - Benefits - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "aYk5MgSCLXP"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "CI8NCm34d7D"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "mu2b9Ivde6J"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WUMjtbgofs2"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "umkL2sEVSNR"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SCY3TdhSz1K"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WS8XV4WWPE7"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "dx"
+                }
+            ],
+            "columnDimensions": [
+                "dx"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": [
+                "ou"
+            ],
+            "rows": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "GIIHAr9BzzO",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "mUCwcWSsa9T",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Achieved total to date (%) - People",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": false,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "CqURW24bmHJ"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "iewd6jLYV4H"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "K6ipXoSOmt2"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "qgGwMTqEq4d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "aOALuHaoaEQ"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "yeQN47GFqwM"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "K2ADN2EmEmr"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "qW6b6ZRfXA5"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "eYmeRzhBFV4"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "u404ICrBKj3"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "K4sH0aQDdeL"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                },
+                {
+                    "id": "201904"
+                },
+                {
+                    "id": "201905"
+                },
+                {
+                    "id": "201906"
+                },
+                {
+                    "id": "201907"
+                },
+                {
+                    "id": "201908"
+                },
+                {
+                    "id": "201909"
+                },
+                {
+                    "id": "201910"
+                },
+                {
+                    "id": "201911"
+                },
+                {
+                    "id": "201912"
+                },
+                {
+                    "id": "202001"
+                },
+                {
+                    "id": "202002"
+                },
+                {
+                    "id": "202003"
+                },
+                {
+                    "id": "202004"
+                },
+                {
+                    "id": "202005"
+                },
+                {
+                    "id": "202006"
+                },
+                {
+                    "id": "202007"
+                },
+                {
+                    "id": "202008"
+                },
+                {
+                    "id": "202009"
+                },
+                {
+                    "id": "202010"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "uSMHdwhxFSV",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                }
+            ],
+            "rowDimensions": [
+                "dx"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ],
+            "legendSet": {
+                "code": "ACTUAL_TARGET_ACHIEVED",
+                "id": "yoAt108kUFm"
+            }
+        },
+        {
+            "id": "ew6e1j5HwkE",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Achieved to date (%) - Benefits",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "qu0x94utOgv"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "qQsafE8eZQt"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "isKcihOpMrF"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "OOIDqW7eQqr"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "m68LzR6ho7V"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "KOKIhtZYDOh"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "eCufXa6RkTm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "i01veyO4Cuw"
                     }
                 }
             ],
@@ -5196,42 +6240,12 @@
             "rows": [
                 {
                     "id": "dx"
-                },
-                {
-                    "code": "ACTUAL_TARGET",
-                    "id": "GIIHAr9BzzO",
-                    "dataDimensionType": "ATTRIBUTE",
-                    "categoryOptions": [
-                        {
-                            "code": "TARGET",
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "code": "ACTUAL",
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
                 }
             ],
             "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
+                "dx"
             ],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "GIIHAr9BzzO"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                }
-            ],
+            "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
             "userAccesses": [
@@ -5252,7 +6266,11 @@
                     "displayName": "Data Management Admin",
                     "access": "rw------"
                 }
-            ]
+            ],
+            "legendSet": {
+                "code": "ACTUAL_TARGET_ACHIEVED",
+                "id": "yoAt108kUFm"
+            }
         },
         {
             "id": "OS2K2s8VIIq",
@@ -5559,9 +6577,9 @@
             ]
         },
         {
-            "id": "ew6e1j5HwkE",
+            "id": "uqMTlezGj0I",
             "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Achieved to date (%) - Benefits",
+            "name": "Award Number 12345 - Target vs Actual - Benefits",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -5573,51 +6591,51 @@
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qu0x94utOgv"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "aYk5MgSCLXP"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qQsafE8eZQt"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "CI8NCm34d7D"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "isKcihOpMrF"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "mu2b9Ivde6J"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "OOIDqW7eQqr"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WUMjtbgofs2"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "m68LzR6ho7V"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "umkL2sEVSNR"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "KOKIhtZYDOh"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SCY3TdhSz1K"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WS8XV4WWPE7"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
                     }
                 }
             ],
@@ -5728,1348 +6746,38 @@
             "rows": [
                 {
                     "id": "dx"
-                }
-            ],
-            "rowDimensions": [
-                "dx"
-            ],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
                 },
                 {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "mUCwcWSsa9T",
-            "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Achieved total to date (%) - People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": false,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "CqURW24bmHJ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "iewd6jLYV4H"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K6ipXoSOmt2"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qgGwMTqEq4d"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "aOALuHaoaEQ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "yeQN47GFqwM"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K2ADN2EmEmr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qW6b6ZRfXA5"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "uSMHdwhxFSV",
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
                     "categoryOptions": [
                         {
-                            "id": "KiK0FMExoqh"
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
                         }
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
-            "filters": [
-                {
-                    "id": "ou"
-                },
-                {
-                    "id": "pe"
-                }
-            ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
             "rowDimensions": [
-                "dx"
+                "dx",
+                "GIIHAr9BzzO"
             ],
             "categoryDimensions": [
                 {
                     "category": {
-                        "id": "uSMHdwhxFSV"
+                        "id": "GIIHAr9BzzO"
                     },
                     "categoryOptions": [
                         {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "KeWVSa2rbYm",
-            "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Achieved (%) - Benefits",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qu0x94utOgv"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qQsafE8eZQt"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "isKcihOpMrF"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "OOIDqW7eQqr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "m68LzR6ho7V"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "KOKIhtZYDOh"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                }
-            ],
-            "columnDimensions": [
-                "pe"
-            ],
-            "filters": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "filterDimensions": [
-                "ou"
-            ],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": [
-                "dx"
-            ],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "i6CWRJp61Hp",
-            "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Achieved to date (%) - People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": false,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "CqURW24bmHJ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "iewd6jLYV4H"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K6ipXoSOmt2"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qgGwMTqEq4d"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "aOALuHaoaEQ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "yeQN47GFqwM"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K2ADN2EmEmr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qW6b6ZRfXA5"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                }
-            ],
-            "columnDimensions": [
-                "pe"
-            ],
-            "filters": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "filterDimensions": [
-                "ou"
-            ],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": [
-                "dx"
-            ],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "eYaYrZfbJT1",
-            "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Achieved total (%) - People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": false,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "CqURW24bmHJ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "iewd6jLYV4H"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K6ipXoSOmt2"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qgGwMTqEq4d"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "aOALuHaoaEQ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "yeQN47GFqwM"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K2ADN2EmEmr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qW6b6ZRfXA5"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "uSMHdwhxFSV",
-                    "categoryOptions": [
+                            "id": "imyqCWQ229K"
+                        },
                         {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
-            "filters": [
-                {
-                    "id": "ou"
-                },
-                {
-                    "id": "pe"
-                }
-            ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": [
-                "dx"
-            ],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "Gi2PegQJhbu",
-            "type": "COLUMN",
-            "name": "Award Number 12345 - Achieved Benefit (%)",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qu0x94utOgv"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qQsafE8eZQt"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "isKcihOpMrF"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "OOIDqW7eQqr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "m68LzR6ho7V"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "KOKIhtZYDOh"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "columnDimensions": [
-                "ou"
-            ],
-            "filters": [
-                {
-                    "id": "pe"
-                }
-            ],
-            "filterDimensions": [
-                "pe"
-            ],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": [
-                "dx"
-            ],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ]
-        },
-        {
-            "id": "Ww2X5s48uQx",
-            "type": "COLUMN",
-            "name": "Award Number 12345 - Achieved People (%)",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "CqURW24bmHJ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "iewd6jLYV4H"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K6ipXoSOmt2"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qgGwMTqEq4d"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "aOALuHaoaEQ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "yeQN47GFqwM"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K2ADN2EmEmr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qW6b6ZRfXA5"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "columnDimensions": [
-                "ou"
-            ],
-            "filters": [
-                {
-                    "id": "pe"
-                },
-                {
-                    "id": "uSMHdwhxFSV",
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV"
-            ],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": [
-                "dx"
-            ],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
+                            "id": "eWeQoOlAcxV"
                         }
                     ]
                 }
@@ -7097,9 +6805,9 @@
             ]
         },
         {
-            "id": "CMqisHj7sP9",
-            "type": "COLUMN",
-            "name": "Award Number 12345 - Achieved by gender (%)",
+            "id": "i8TrzIkXGrG",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Target vs Actual - People - Month by Month",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -7111,69 +6819,69 @@
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "CqURW24bmHJ"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "iewd6jLYV4H"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K6ipXoSOmt2"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qgGwMTqEq4d"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "aOALuHaoaEQ"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "yeQN47GFqwM"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K2ADN2EmEmr"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qW6b6ZRfXA5"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
                     }
                 }
             ],
@@ -7190,82 +6898,93 @@
             ],
             "periods": [
                 {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
                     "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
                 },
                 {
                     "id": "202001"
                 },
                 {
+                    "id": "201902"
+                },
+                {
                     "id": "202002"
+                },
+                {
+                    "id": "201903"
                 },
                 {
                     "id": "202003"
                 },
                 {
+                    "id": "201904"
+                },
+                {
                     "id": "202004"
+                },
+                {
+                    "id": "201905"
                 },
                 {
                     "id": "202005"
                 },
                 {
+                    "id": "201906"
+                },
+                {
                     "id": "202006"
+                },
+                {
+                    "id": "201907"
                 },
                 {
                     "id": "202007"
                 },
                 {
+                    "id": "201908"
+                },
+                {
                     "id": "202008"
+                },
+                {
+                    "id": "201909"
                 },
                 {
                     "id": "202009"
                 },
                 {
+                    "id": "201810"
+                },
+                {
+                    "id": "201910"
+                },
+                {
                     "id": "202010"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201911"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201912"
                 }
             ],
             "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
                 {
                     "code": "GENDER",
                     "id": "Kyg1O6YEGa9",
@@ -7280,41 +6999,66 @@
                             "id": "yW2hYVS3S4u"
                         }
                     ]
-                }
-            ],
-            "columnDimensions": [
-                "Kyg1O6YEGa9"
-            ],
-            "filters": [
-                {
-                    "id": "ou"
                 },
                 {
-                    "id": "pe"
-                },
-                {
+                    "code": "NEW_RETURNING",
                     "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
                     "categoryOptions": [
                         {
+                            "code": "NEW",
                             "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
                         }
                     ]
                 }
             ],
             "filterDimensions": [
                 "ou",
-                "pe",
+                "Kyg1O6YEGa9",
                 "uSMHdwhxFSV"
             ],
             "rows": [
                 {
                     "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
                 }
             ],
             "rowDimensions": [
-                "dx"
+                "dx",
+                "GIIHAr9BzzO"
             ],
             "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
                 {
                     "category": {
                         "id": "Kyg1O6YEGa9"
@@ -7335,6 +7079,9 @@
                     "categoryOptions": [
                         {
                             "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
                         }
                     ]
                 }
@@ -7362,9 +7109,9 @@
             ]
         },
         {
-            "id": "WGWGaYtwJzp",
-            "type": "COLUMN",
-            "name": "Award Number 12345 - Benefits Per Person",
+            "id": "aGYruOfBtaD",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Target vs Actual - Benefits - Month by Month",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -7376,9 +7123,51 @@
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "Gob5qHAX60C"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "aYk5MgSCLXP"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "CI8NCm34d7D"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "mu2b9Ivde6J"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WUMjtbgofs2"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "umkL2sEVSNR"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SCY3TdhSz1K"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WS8XV4WWPE7"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
                     }
                 }
             ],
@@ -7395,106 +7184,1008 @@
             ],
             "periods": [
                 {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
                     "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
                 },
                 {
                     "id": "202001"
                 },
                 {
+                    "id": "201902"
+                },
+                {
                     "id": "202002"
+                },
+                {
+                    "id": "201903"
                 },
                 {
                     "id": "202003"
                 },
                 {
+                    "id": "201904"
+                },
+                {
                     "id": "202004"
+                },
+                {
+                    "id": "201905"
                 },
                 {
                     "id": "202005"
                 },
                 {
+                    "id": "201906"
+                },
+                {
                     "id": "202006"
+                },
+                {
+                    "id": "201907"
                 },
                 {
                     "id": "202007"
                 },
                 {
+                    "id": "201908"
+                },
+                {
                     "id": "202008"
+                },
+                {
+                    "id": "201909"
                 },
                 {
                     "id": "202009"
                 },
                 {
+                    "id": "201810"
+                },
+                {
+                    "id": "201910"
+                },
+                {
                     "id": "202010"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201911"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201912"
                 }
             ],
             "columns": [
                 {
-                    "id": "ou"
-                }
-            ],
-            "columnDimensions": [
-                "ou"
-            ],
-            "filters": [
-                {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
+            "columnDimensions": [
                 "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": [
+                "ou"
             ],
             "rows": [
                 {
                     "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
                 }
             ],
             "rowDimensions": [
-                "dx"
+                "dx",
+                "GIIHAr9BzzO"
             ],
-            "categoryDimensions": [],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "KoIzyX81ZVL",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Target vs Actual - People - Male Only - Pivot Table",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "id": "uSMHdwhxFSV",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "WikhmLU9agJ",
+            "type": "COLUMN",
+            "name": "Award Number 12345 - Target vs Actual - People - Male Only - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "id": "uSMHdwhxFSV",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "yamOXKh6Vok",
+            "type": "PIVOT_TABLE",
+            "name": "Award Number 12345 - Target vs Actual - People - Female Only - Pivot Table",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "id": "uSMHdwhxFSV",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "yaQ772dtmLb",
+            "type": "COLUMN",
+            "name": "Award Number 12345 - Target vs Actual - People - Female Only - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "SQy5q6kCYI1"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iYEDR850FFL"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qkyeCTJHU2d"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "eAkVLI8mKBa"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "Kg29718LQHl"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "KKmUWsn19fq"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "iCKxYSFIlcu"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "qAM1NbCbS9G"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                },
+                {
+                    "id": "TvSmIyYcRnd"
+                },
+                {
+                    "id": "cqZ9zQfePzQ"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "2018"
+                },
+                {
+                    "id": "2019"
+                },
+                {
+                    "id": "2020"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": [
+                "pe"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "id": "uSMHdwhxFSV",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        }
+                    ]
+                }
+            ],
             "publicAccess": "--------",
             "externalAccess": false,
             "userAccesses": [

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1062,6 +1062,17 @@
                     "y": 40
                 },
                 {
+                    "id": "a4GacNVWHLX",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "GA87u7JwgSK"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 60
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1069,7 +1080,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 60
                 },
                 {
@@ -1080,8 +1091,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 60
+                    "x": 0,
+                    "y": 80
                 },
                 {
                     "id": "qMSWdZHPjyN",
@@ -1091,7 +1102,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 80
                 },
                 {
@@ -1102,8 +1113,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 80
+                    "x": 0,
+                    "y": 100
                 },
                 {
                     "id": "mgwFIMjbsdw",
@@ -1113,7 +1124,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 100
                 },
                 {
@@ -1475,7 +1486,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1484,13 +1497,18 @@
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["dx", "ou"],
+            "filterDimensions": [
+                "dx",
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1603,7 +1621,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1642,13 +1662,20 @@
                     ]
                 }
             ],
-            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "dx",
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1775,19 +1802,25 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1882,13 +1915,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -1909,7 +1946,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2004,19 +2044,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -2101,13 +2147,17 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
@@ -2128,7 +2178,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["pe", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2140,6 +2193,199 @@
                         },
                         {
                             "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "GA87u7JwgSK",
+            "type": "COLUMN",
+            "name": "12345en - MyProject - Target vs Actual - People - Column Chart Disaggregated By Indicator",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "dx"
+                }
+            ],
+            "columnDimensions": [
+                "dx"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "code": "GENDER",
+                    "id": "Kyg1O6YEGa9",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "MALE",
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "code": "FEMALE",
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "pe"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
                         }
                     ]
                 }
@@ -2244,13 +2490,18 @@
                     ]
                 }
             ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "pe",
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2286,7 +2537,11 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2418,7 +2673,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2427,13 +2684,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2529,19 +2791,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -2632,19 +2900,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -2740,7 +3014,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2749,13 +3025,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2869,19 +3150,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -2962,19 +3249,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3061,7 +3354,9 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -3075,13 +3370,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3191,7 +3491,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3208,13 +3510,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3313,19 +3621,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3450,7 +3764,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -3472,13 +3788,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": ["ou"],
+            "rowDimensions": [
+                "ou"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3586,7 +3908,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -3600,13 +3924,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": ["ou"],
+            "rowDimensions": [
+                "ou"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3716,7 +4045,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3738,13 +4069,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "uSMHdwhxFSV", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "ou",
+                "uSMHdwhxFSV",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3846,7 +4183,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3860,13 +4199,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "ou",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4037,13 +4381,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -4064,7 +4412,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4291,13 +4642,18 @@
                     ]
                 }
             ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "pe",
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -4333,7 +4689,11 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4553,19 +4913,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4772,7 +5138,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -4781,13 +5149,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4982,19 +5355,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -5196,19 +5575,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -5415,7 +5800,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -5424,13 +5811,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5691,19 +6083,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -5883,19 +6281,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6093,7 +6497,9 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -6107,13 +6513,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6334,7 +6745,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -6351,13 +6764,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6519,19 +6938,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1294,7 +1294,27 @@
                 }
             ],
             "sharing": {
-                "public": "rw------"
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
+                }
             }
         },
         {
@@ -4603,7 +4623,27 @@
                 }
             ],
             "sharing": {
-                "public": "rw------"
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
+                }
             }
         },
         {
@@ -4726,7 +4766,27 @@
                 }
             ],
             "sharing": {
-                "public": "rw------"
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
+                }
             }
         },
         {
@@ -4879,7 +4939,27 @@
                 }
             ],
             "sharing": {
-                "public": "rw------"
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
+                }
             }
         },
         {
@@ -4996,7 +5076,27 @@
                 }
             ],
             "sharing": {
-                "public": "rw------"
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
+                }
             }
         },
         {

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1106,6 +1106,17 @@
                     "y": 80
                 },
                 {
+                    "id": "OgO4mL6ovvU",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "KasxZ8vT1n0"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 100
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1113,7 +1124,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 100
                 },
                 {
@@ -1124,8 +1135,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 100
+                    "x": 0,
+                    "y": 120
                 },
                 {
                     "id": "qMSWdZHPjyN",
@@ -1135,7 +1146,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 120
                 },
                 {
@@ -1146,8 +1157,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 120
+                    "x": 0,
+                    "y": 140
                 },
                 {
                     "id": "mgwFIMjbsdw",
@@ -1157,7 +1168,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 140
                 },
                 {
@@ -2911,6 +2922,189 @@
                     "categoryOptions": [
                         {
                             "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "KasxZ8vT1n0",
+            "type": "LINE",
+            "name": "12345en - MyProject - Target vs Actual - People - Line Chart - Female Only",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
                         }
                     ]
                 },

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1018,6 +1018,17 @@
                     "y": 0
                 },
                 {
+                    "id": "WQwlyfCElo8",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "yWq2ZBWiK8T"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 20
+                },
+                {
                     "id": "Ka4yijY2Vhl",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1025,7 +1036,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 20
                 },
                 {
@@ -1036,8 +1047,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 20
+                    "x": 0,
+                    "y": 40
                 },
                 {
                     "id": "y2G8oh7xQBm",
@@ -1047,7 +1058,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 40
                 },
                 {
@@ -1058,8 +1069,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 40
+                    "x": 0,
+                    "y": 60
                 },
                 {
                     "id": "ywvTGMsKdwL",
@@ -1069,7 +1080,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 60
                 },
                 {
@@ -1080,8 +1091,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 60
+                    "x": 0,
+                    "y": 80
                 },
                 {
                     "id": "uyoJujQVRjE",
@@ -1091,7 +1102,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 80
                 },
                 {
@@ -1102,8 +1113,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 80
+                    "x": 0,
+                    "y": 100
                 },
                 {
                     "id": "ys0CVedHirZ",
@@ -1114,7 +1125,7 @@
                     "width": 58,
                     "height": 20,
                     "x": 0,
-                    "y": 100
+                    "y": 120
                 },
                 {
                     "id": "KI0C90Ol10x",
@@ -1125,7 +1136,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 120
+                    "y": 140
                 },
                 {
                     "id": "uYY7v977Ubm",
@@ -1136,7 +1147,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 120
+                    "y": 140
                 },
                 {
                     "id": "qUqsDmtiBLF",
@@ -1147,7 +1158,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 140
+                    "y": 160
                 },
                 {
                     "id": "mwMpIdPdu8H",
@@ -1158,7 +1169,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 140
+                    "y": 160
                 }
             ],
             "publicAccess": "--------",
@@ -1686,6 +1697,119 @@
                         },
                         {
                             "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "yWq2ZBWiK8T",
+            "type": "COLUMN",
+            "name": "12345en - MyProject - MER - Target vs Actual - Benefits - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": ["ou"],
+            "rows": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": ["pe"],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
                         }
                     ]
                 }

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1084,6 +1084,17 @@
                     "y": 60
                 },
                 {
+                    "id": "a6cSVlR6bSj",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "GkoTRBEmIQt"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 80
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1091,7 +1102,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 80
                 },
                 {
@@ -1102,8 +1113,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 80
+                    "x": 0,
+                    "y": 100
                 },
                 {
                     "id": "qMSWdZHPjyN",
@@ -1113,7 +1124,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 100
                 },
                 {
@@ -1124,8 +1135,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 100
+                    "x": 0,
+                    "y": 120
                 },
                 {
                     "id": "mgwFIMjbsdw",
@@ -1135,7 +1146,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 120
                 },
                 {
@@ -2526,6 +2537,199 @@
                         },
                         {
                             "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "GkoTRBEmIQt",
+            "type": "LINE",
+            "name": "12345en - MyProject - Target vs Actual - People - Line Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "code": "GENDER",
+                    "id": "Kyg1O6YEGa9",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "MALE",
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "code": "FEMALE",
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
                         }
                     ]
                 }

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -546,27 +546,29 @@
                     }
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rwrw----"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rwrw----"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rwrw----"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rwrw----"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rwrw----"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rwrw----"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "CwUxT9UIX3z",
@@ -967,27 +969,29 @@
                     }
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rwrw----"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rwrw----"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rwrw----"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rwrw----"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rwrw----"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rwrw----"
+                    }
                 }
-            ]
+            }
         }
     ],
     "dashboards": [
@@ -997,7 +1001,7 @@
             "dashboardItems": [
                 {
                     "id": "uOsjh5OmILO",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "ywQZlYBN4nN"
                     },
@@ -1008,7 +1012,7 @@
                 },
                 {
                     "id": "mouU4wUzbJ3",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "q0Arl96SxH5"
                     },
@@ -1019,7 +1023,7 @@
                 },
                 {
                     "id": "WQwlyfCElo8",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "yWq2ZBWiK8T"
                     },
@@ -1030,7 +1034,7 @@
                 },
                 {
                     "id": "imK8xQLwwYX",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "uYWdSMZQ1LH"
                     },
@@ -1041,7 +1045,7 @@
                 },
                 {
                     "id": "Ka4yijY2Vhl",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "i07AWJAND8a"
                     },
@@ -1052,7 +1056,7 @@
                 },
                 {
                     "id": "yWGKgz9vaOh",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "iqqgnCj9DQj"
                     },
@@ -1063,7 +1067,7 @@
                 },
                 {
                     "id": "i66m5HwnH6v",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "a46jcQ65Axt"
                     },
@@ -1074,7 +1078,7 @@
                 },
                 {
                     "id": "a4GacNVWHLX",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "GA87u7JwgSK"
                     },
@@ -1085,7 +1089,7 @@
                 },
                 {
                     "id": "KYcDaXAZa1q",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "KiUTxsMMYde"
                     },
@@ -1096,7 +1100,7 @@
                 },
                 {
                     "id": "a6cSVlR6bSj",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "GkoTRBEmIQt"
                     },
@@ -1107,7 +1111,7 @@
                 },
                 {
                     "id": "W4DOghdXUmp",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "S2kJHgM41El"
                     },
@@ -1118,7 +1122,7 @@
                 },
                 {
                     "id": "OgO4mL6ovvU",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "KasxZ8vT1n0"
                     },
@@ -1129,7 +1133,7 @@
                 },
                 {
                     "id": "K2amO1SBZFm",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "W2SCFrHCiEm"
                     },
@@ -1140,7 +1144,7 @@
                 },
                 {
                     "id": "GW6MALzFIVR",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "OuKm5zK7l53"
                     },
@@ -1151,7 +1155,7 @@
                 },
                 {
                     "id": "m4LaU9HizHi",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "iOk52Z42bjp"
                     },
@@ -1162,7 +1166,7 @@
                 },
                 {
                     "id": "uyoJujQVRjE",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "GM6SxObVwI3"
                     },
@@ -1173,7 +1177,7 @@
                 },
                 {
                     "id": "KI0C90Ol10x",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "qmsj4FqnVPX"
                     },
@@ -1184,7 +1188,7 @@
                 },
                 {
                     "id": "uYY7v977Ubm",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "uiyYMLiDaK2"
                     },
@@ -1195,7 +1199,7 @@
                 },
                 {
                     "id": "qUqsDmtiBLF",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "u6Sin4Fy1Wt"
                     },
@@ -1206,7 +1210,7 @@
                 },
                 {
                     "id": "mwMpIdPdu8H",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "ukewRkZsyCI"
                     },
@@ -1216,27 +1220,29 @@
                     "y": 180
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "qyG6foGIKEx",
@@ -1244,7 +1250,7 @@
             "dashboardItems": [
                 {
                     "id": "e6UAresDcfM",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "GqYJDh6asM8"
                     },
@@ -1255,7 +1261,7 @@
                 },
                 {
                     "id": "CQuufxhy672",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "me6p7L8VHXl"
                     },
@@ -1266,7 +1272,7 @@
                 },
                 {
                     "id": "eUSMAePgCN9",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "KOiGcdA4JjD"
                     },
@@ -1277,7 +1283,7 @@
                 },
                 {
                     "id": "GWKMgoU2E38",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "CS7csnUtibF"
                     },
@@ -1287,7 +1293,9 @@
                     "y": 90
                 }
             ],
-            "publicAccess": "rw------"
+            "sharing": {
+                "public": "rw------"
+            }
         },
         {
             "id": "OiCmorbkHNf",
@@ -1295,7 +1303,7 @@
             "dashboardItems": [
                 {
                     "id": "CSL3EN6eJwx",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "CAEdMM5XM5T"
                     },
@@ -1306,7 +1314,7 @@
                 },
                 {
                     "id": "iYkPSnM7m4E",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "GiUz1pZI2Rq"
                     },
@@ -1317,7 +1325,7 @@
                 },
                 {
                     "id": "yI8WlxGRfXU",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "uwoFl2upiOM"
                     },
@@ -1328,7 +1336,7 @@
                 },
                 {
                     "id": "aCiqCXWYZ9P",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "ui6nUS98GBM"
                     },
@@ -1339,7 +1347,7 @@
                 },
                 {
                     "id": "KEy2fuNrALy",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "mUCwcWSsa9T"
                     },
@@ -1350,7 +1358,7 @@
                 },
                 {
                     "id": "O0uabsxLqGS",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "ew6e1j5HwkE"
                     },
@@ -1361,7 +1369,7 @@
                 },
                 {
                     "id": "GCm9PNnLAgP",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "OS2K2s8VIIq"
                     },
@@ -1372,7 +1380,7 @@
                 },
                 {
                     "id": "W4EN8esNyGQ",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "uqMTlezGj0I"
                     },
@@ -1383,7 +1391,7 @@
                 },
                 {
                     "id": "OuQLaEe9G9v",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "i8TrzIkXGrG"
                     },
@@ -1394,7 +1402,7 @@
                 },
                 {
                     "id": "i60k7CBbyJZ",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "aGYruOfBtaD"
                     },
@@ -1405,7 +1413,7 @@
                 },
                 {
                     "id": "qeWaohT6Mgt",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "KoIzyX81ZVL"
                     },
@@ -1416,7 +1424,7 @@
                 },
                 {
                     "id": "y84WQGCtWxT",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "WikhmLU9agJ"
                     },
@@ -1427,7 +1435,7 @@
                 },
                 {
                     "id": "eCWMTNjreWb",
-                    "type": "REPORT_TABLE",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "yamOXKh6Vok"
                     },
@@ -1438,7 +1446,7 @@
                 },
                 {
                     "id": "eUcnQVKRn34",
-                    "type": "CHART",
+                    "type": "VISUALIZATION",
                     "visualization": {
                         "id": "yaQ772dtmLb"
                     },
@@ -1448,27 +1456,29 @@
                     "y": 120
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         }
     ],
     "visualizations": [
@@ -1477,12 +1487,15 @@
             "type": "COLUMN",
             "name": "12345en - MyProject - Target vs Actual - Benefits - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -1541,7 +1554,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1550,13 +1565,18 @@
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["dx", "ou"],
+            "filterDimensions": [
+                "dx",
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1572,39 +1592,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "q0Arl96SxH5",
             "type": "COLUMN",
             "name": "12345en - MyProject - Target vs Actual - People - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -1669,7 +1694,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1708,13 +1735,20 @@
                     ]
                 }
             ],
-            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "dx",
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1756,39 +1790,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "yWq2ZBWiK8T",
             "type": "COLUMN",
             "name": "12345en - MyProject - MER - Target vs Actual - Benefits - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -1841,19 +1880,25 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1869,39 +1914,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "uYWdSMZQ1LH",
             "type": "COLUMN",
             "name": "12345en - MyProject - MER - Target vs Actual - People - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -1954,7 +2004,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1993,13 +2045,20 @@
                     ]
                 }
             ],
-            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "dx",
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2041,39 +2100,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "i07AWJAND8a",
             "type": "PIVOT_TABLE",
             "name": "12345en - MyProject - Target vs Actual - Benefits",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -2120,13 +2184,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2147,7 +2215,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2163,39 +2234,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "iqqgnCj9DQj",
             "type": "PIVOT_TABLE",
             "name": "12345en - MyProject - Target vs Actual - People",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -2263,13 +2339,18 @@
                     ]
                 }
             ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "pe",
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2305,7 +2386,11 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2347,39 +2432,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "a46jcQ65Axt",
             "type": "COLUMN",
             "name": "12345en - MyProject - Target vs Actual - Benefits - Column Chart Disaggregated By Indicator",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -2426,13 +2516,17 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
@@ -2453,7 +2547,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["pe", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2469,39 +2566,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "GA87u7JwgSK",
             "type": "COLUMN",
             "name": "12345en - MyProject - Target vs Actual - People - Column Chart Disaggregated By Indicator",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -2554,7 +2656,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2590,7 +2694,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "pe"
@@ -2611,7 +2719,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["pe", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2653,39 +2764,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "KiUTxsMMYde",
             "type": "LINE",
             "name": "12345en - MyProject - Target vs Actual - Benefits - Line Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -2744,13 +2860,17 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2759,7 +2879,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2775,39 +2898,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "GkoTRBEmIQt",
             "type": "LINE",
             "name": "12345en - MyProject - Target vs Actual - People - Line Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -2872,7 +3000,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2908,7 +3038,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2917,7 +3051,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2959,39 +3096,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "S2kJHgM41El",
             "type": "LINE",
             "name": "12345en - MyProject - Target vs Actual - People - Line Chart - Male Only",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3056,7 +3198,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3085,7 +3229,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3094,7 +3242,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3133,39 +3284,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "KasxZ8vT1n0",
             "type": "LINE",
             "name": "12345en - MyProject - Target vs Actual - People - Line Chart - Female Only",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3230,7 +3386,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3259,7 +3417,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3268,7 +3430,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3307,39 +3472,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "W2SCFrHCiEm",
             "type": "LINE",
             "name": "12345en - MyProject - Target vs Actual - People - Line/Column Chart - Male Only",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3404,7 +3574,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3433,7 +3605,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3442,7 +3618,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3481,27 +3660,29 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ],
+            },
             "series": [
                 {
                     "dimensionItem": "imyqCWQ229K",
@@ -3519,12 +3700,15 @@
             "type": "LINE",
             "name": "12345en - MyProject - Target vs Actual - People - Line/Column Chart - Female Only",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3589,7 +3773,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3618,7 +3804,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3627,7 +3817,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3666,27 +3859,29 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ],
+            },
             "series": [
                 {
                     "dimensionItem": "imyqCWQ229K",
@@ -3704,12 +3899,16 @@
             "type": "PIVOT_TABLE",
             "name": "12345en - MyProject - Achieved to date (%) - Benefits",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "set": {
+                    "code": "ACTUAL_TARGET_ACHIEVED",
+                    "id": "yoAt108kUFm"
+                }
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3756,44 +3955,48 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
             }
         },
         {
@@ -3801,12 +4004,16 @@
             "type": "PIVOT_TABLE",
             "name": "12345en - MyProject - Achieved to date (%) - People",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "set": {
+                    "code": "ACTUAL_TARGET_ACHIEVED",
+                    "id": "yoAt108kUFm"
+                }
+            },
             "rowTotals": false,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3859,44 +4066,48 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
             }
         },
         {
@@ -3904,12 +4115,15 @@
             "type": "COLUMN",
             "name": "12345en - MyProject - Achieved Benefit (%)",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -3956,53 +4170,64 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
+            "rowDimensions": [
+                "dx"
             ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "categoryDimensions": [],
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "uiyYMLiDaK2",
             "type": "COLUMN",
             "name": "12345en - MyProject - Achieved People (%)",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4055,7 +4280,9 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -4069,13 +4296,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4088,39 +4320,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "u6Sin4Fy1Wt",
             "type": "COLUMN",
             "name": "12345en - MyProject - Achieved by gender (%)",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4185,7 +4422,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -4202,13 +4441,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4234,39 +4479,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "ukewRkZsyCI",
             "type": "COLUMN",
             "name": "12345en - MyProject - Benefits Per Person",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4307,53 +4557,64 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
+            "rowDimensions": [
+                "dx"
             ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "categoryDimensions": [],
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "KOiGcdA4JjD",
             "type": "PIVOT_TABLE",
             "name": "[Bahamas] Projects - People",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4444,7 +4705,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -4466,13 +4729,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": ["ou"],
+            "rowDimensions": [
+                "ou"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4495,19 +4764,24 @@
                     ]
                 }
             ],
-            "publicAccess": "rw------"
+            "sharing": {
+                "public": "rw------"
+            }
         },
         {
             "id": "CS7csnUtibF",
             "type": "PIVOT_TABLE",
             "name": "[Bahamas] Projects - Benefit",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4580,7 +4854,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -4594,13 +4870,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": ["ou"],
+            "rowDimensions": [
+                "ou"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4613,19 +4894,24 @@
                     ]
                 }
             ],
-            "publicAccess": "rw------"
+            "sharing": {
+                "public": "rw------"
+            }
         },
         {
             "id": "GqYJDh6asM8",
             "type": "COLUMN",
             "name": "[Bahamas] Aggregated Actual Values - People",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4710,7 +4996,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -4732,13 +5020,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "uSMHdwhxFSV", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "ou",
+                "uSMHdwhxFSV",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4761,19 +5055,24 @@
                     ]
                 }
             ],
-            "publicAccess": "rw------"
+            "sharing": {
+                "public": "rw------"
+            }
         },
         {
             "id": "me6p7L8VHXl",
             "type": "COLUMN",
             "name": "[Bahamas] Aggregated Actual Values - Benefit",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4840,7 +5139,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -4854,13 +5155,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "ou",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4873,19 +5179,24 @@
                     ]
                 }
             ],
-            "publicAccess": "rw------"
+            "sharing": {
+                "public": "rw------"
+            }
         },
         {
             "id": "CAEdMM5XM5T",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - People - Pivot Table",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -4983,13 +5294,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -5025,7 +5340,11 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5054,39 +5373,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "GiUz1pZI2Rq",
             "type": "COLUMN",
             "name": "Award Number 12345 - Target vs Actual - People - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -5184,7 +5508,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -5220,7 +5546,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "code": "ACTUAL_TARGET",
@@ -5241,7 +5571,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["GIIHAr9BzzO", "pe"],
+            "rowDimensions": [
+                "GIIHAr9BzzO",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5283,39 +5616,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "uwoFl2upiOM",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - Benefits - Pivot Table",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -5395,13 +5733,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -5422,7 +5764,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5438,39 +5783,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "ui6nUS98GBM",
             "type": "COLUMN",
             "name": "Award Number 12345 - Target vs Actual - Benefits - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -5550,13 +5900,17 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "code": "ACTUAL_TARGET",
@@ -5577,7 +5931,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["GIIHAr9BzzO", "pe"],
+            "rowDimensions": [
+                "GIIHAr9BzzO",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5593,39 +5950,45 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "mUCwcWSsa9T",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Achieved total to date (%) - People",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "set": {
+                    "code": "ACTUAL_TARGET_ACHIEVED",
+                    "id": "yoAt108kUFm"
+                }
+            },
             "rowTotals": false,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -5794,7 +6157,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -5803,13 +6168,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5822,30 +6192,28 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
             }
         },
         {
@@ -5853,12 +6221,16 @@
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Achieved to date (%) - Benefits",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "set": {
+                    "code": "ACTUAL_TARGET_ACHIEVED",
+                    "id": "yoAt108kUFm"
+                }
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -6004,44 +6376,48 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
             }
         },
         {
@@ -6049,12 +6425,15 @@
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - People",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -6233,13 +6612,18 @@
                     ]
                 }
             ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "pe",
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -6275,7 +6659,11 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6317,39 +6705,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "uqMTlezGj0I",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - Benefits",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -6495,13 +6888,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -6522,7 +6919,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6538,39 +6938,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "i8TrzIkXGrG",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - People - Month by Month",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -6734,7 +7139,9 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -6770,7 +7177,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -6791,7 +7202,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6833,39 +7247,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "aGYruOfBtaD",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - Benefits - Month by Month",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -7011,13 +7430,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -7038,7 +7461,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7054,39 +7480,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "KoIzyX81ZVL",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - People - Male Only - Pivot Table",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -7184,7 +7615,9 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -7206,7 +7639,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -7227,7 +7664,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7263,39 +7703,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "WikhmLU9agJ",
             "type": "COLUMN",
             "name": "Award Number 12345 - Target vs Actual - People - Male Only - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -7393,7 +7838,9 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -7415,7 +7862,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -7436,7 +7887,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7472,39 +7926,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "yamOXKh6Vok",
             "type": "PIVOT_TABLE",
             "name": "Award Number 12345 - Target vs Actual - People - Female Only - Pivot Table",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -7602,7 +8061,9 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -7624,7 +8085,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -7645,7 +8110,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7681,39 +8149,44 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         },
         {
             "id": "yaQ772dtmLb",
             "type": "COLUMN",
             "name": "Award Number 12345 - Target vs Actual - People - Female Only - Column Chart",
             "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
             "showDimensionLabels": true,
             "showData": true,
             "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
+            "legend": {
+                "strategy": "FIXED",
+                "style": "FILL",
+                "showKey": false
+            },
             "rowTotals": true,
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
@@ -7811,7 +8284,9 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -7833,7 +8308,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -7854,7 +8333,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7890,27 +8372,29 @@
                     ]
                 }
             ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rw------"
+                    }
                 },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rw------"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rw------"
+                    }
                 }
-            ]
+            }
         }
     ]
 }

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1117,6 +1117,17 @@
                     "y": 100
                 },
                 {
+                    "id": "K2amO1SBZFm",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "W2SCFrHCiEm"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 100
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1124,8 +1135,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 100
+                    "x": 0,
+                    "y": 120
                 },
                 {
                     "id": "ywvTGMsKdwL",
@@ -1135,7 +1146,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 120
                 },
                 {
@@ -1146,8 +1157,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 120
+                    "x": 0,
+                    "y": 140
                 },
                 {
                     "id": "uyoJujQVRjE",
@@ -1157,7 +1168,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 140
                 },
                 {
@@ -1168,8 +1179,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 140
+                    "x": 0,
+                    "y": 160
                 },
                 {
                     "id": "ys0CVedHirZ",
@@ -1180,7 +1191,7 @@
                     "width": 58,
                     "height": 20,
                     "x": 0,
-                    "y": 160
+                    "y": 180
                 },
                 {
                     "id": "KI0C90Ol10x",
@@ -1191,7 +1202,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 180
+                    "y": 200
                 },
                 {
                     "id": "uYY7v977Ubm",
@@ -1202,7 +1213,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 180
+                    "y": 200
                 },
                 {
                     "id": "qUqsDmtiBLF",
@@ -1213,7 +1224,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 200
+                    "y": 220
                 },
                 {
                     "id": "mwMpIdPdu8H",
@@ -1224,7 +1235,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 200
+                    "y": 220
                 }
             ],
             "publicAccess": "--------",
@@ -3141,6 +3152,200 @@
                     "id": "mKKNXzeIAJs",
                     "displayName": "Data Management Admin",
                     "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "W2SCFrHCiEm",
+            "type": "LINE",
+            "name": "12345en - MyProject - Target vs Actual - People - Line/Column Chart - Male Only",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ],
+            "series": [
+                {
+                    "dimensionItem": "imyqCWQ229K",
+                    "axis": 0
+                },
+                {
+                    "dimensionItem": "eWeQoOlAcxV",
+                    "axis": 0,
+                    "type": "COLUMN"
                 }
             ]
         },

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1128,6 +1128,17 @@
                     "y": 100
                 },
                 {
+                    "id": "GW6MALzFIVR",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "OuKm5zK7l53"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 120
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1135,7 +1146,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 120
                 },
                 {
@@ -1146,8 +1157,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 120
+                    "x": 0,
+                    "y": 140
                 },
                 {
                     "id": "qMSWdZHPjyN",
@@ -1157,7 +1168,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 140
                 },
                 {
@@ -1168,8 +1179,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 140
+                    "x": 0,
+                    "y": 160
                 },
                 {
                     "id": "mgwFIMjbsdw",
@@ -1179,7 +1190,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 160
                 },
                 {
@@ -1541,9 +1552,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -1552,18 +1561,13 @@
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou"
-            ],
+            "filterDimensions": ["dx", "ou"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1676,9 +1680,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -1717,20 +1719,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1857,25 +1852,19 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1970,17 +1959,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2001,10 +1986,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2099,25 +2081,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -2202,17 +2178,13 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "pe"
@@ -2233,10 +2205,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2337,9 +2306,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -2375,11 +2342,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
@@ -2400,10 +2363,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2536,17 +2496,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2555,10 +2511,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2671,9 +2624,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -2709,11 +2660,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -2722,10 +2669,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2864,9 +2808,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -2895,11 +2837,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -2908,10 +2846,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3047,9 +2982,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3078,11 +3011,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3091,10 +3020,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3230,9 +3156,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3261,11 +3185,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3274,10 +3194,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3299,6 +3216,191 @@
                     "categoryOptions": [
                         {
                             "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ],
+            "series": [
+                {
+                    "dimensionItem": "imyqCWQ229K",
+                    "axis": 0
+                },
+                {
+                    "dimensionItem": "eWeQoOlAcxV",
+                    "axis": 0,
+                    "type": "COLUMN"
+                }
+            ]
+        },
+        {
+            "id": "OuKm5zK7l53",
+            "type": "LINE",
+            "name": "12345en - MyProject - Target vs Actual - People - Line/Column Chart - Female Only",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": ["dx", "pe"],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "yW2hYVS3S4u"
                         }
                     ]
                 },
@@ -3427,18 +3529,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "pe",
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -3474,11 +3571,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3610,9 +3703,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
+            "columnDimensions": ["uSMHdwhxFSV"],
             "filters": [
                 {
                     "id": "ou"
@@ -3621,18 +3712,13 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
+            "filterDimensions": ["ou", "pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3728,25 +3814,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3777,7 +3857,7 @@
         {
             "id": "GM6SxObVwI3",
             "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Achieved (%) - People",
+            "name": "12345en - MyProject - Achieved to date (%) - People",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -3837,25 +3917,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3951,9 +4025,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
+            "columnDimensions": ["uSMHdwhxFSV"],
             "filters": [
                 {
                     "id": "ou"
@@ -3962,18 +4034,13 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
+            "filterDimensions": ["ou", "pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4087,25 +4154,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4186,25 +4247,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4291,9 +4346,7 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
@@ -4307,18 +4360,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4428,9 +4476,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
@@ -4447,19 +4493,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4558,25 +4598,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4701,9 +4735,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "pe"
@@ -4725,19 +4757,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": [
-                "ou"
-            ],
+            "rowDimensions": ["ou"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4845,9 +4871,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "pe"
@@ -4861,18 +4885,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["pe", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": [
-                "ou"
-            ],
+            "rowDimensions": ["ou"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4982,9 +5001,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5006,19 +5023,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "uSMHdwhxFSV",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["ou", "uSMHdwhxFSV", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5120,9 +5131,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5136,18 +5145,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["ou", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5318,17 +5322,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -5349,10 +5349,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5579,18 +5576,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "pe",
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -5626,11 +5618,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5850,25 +5838,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6075,9 +6057,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
+            "columnDimensions": ["uSMHdwhxFSV"],
             "filters": [
                 {
                     "id": "ou"
@@ -6086,18 +6066,13 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
+            "filterDimensions": ["ou", "pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6292,25 +6267,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6341,7 +6310,7 @@
         {
             "id": "i6CWRJp61Hp",
             "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Achieved (%) - People",
+            "name": "Award Number 12345 - Achieved to date (%) - People",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -6512,25 +6481,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6737,9 +6700,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
+            "columnDimensions": ["uSMHdwhxFSV"],
             "filters": [
                 {
                     "id": "ou"
@@ -6748,18 +6709,13 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
+            "filterDimensions": ["ou", "pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7020,25 +6976,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -7218,25 +7168,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -7434,9 +7378,7 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
@@ -7450,18 +7392,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7682,9 +7619,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
@@ -7701,19 +7636,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7875,25 +7804,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1095,6 +1095,17 @@
                     "y": 80
                 },
                 {
+                    "id": "W4DOghdXUmp",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "S2kJHgM41El"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 80
+                },
+                {
                     "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1102,8 +1113,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 80
+                    "x": 0,
+                    "y": 100
                 },
                 {
                     "id": "ywvTGMsKdwL",
@@ -1113,7 +1124,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 100
                 },
                 {
@@ -1124,8 +1135,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 100
+                    "x": 0,
+                    "y": 120
                 },
                 {
                     "id": "uyoJujQVRjE",
@@ -1135,7 +1146,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 120
                 },
                 {
@@ -1146,8 +1157,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 120
+                    "x": 0,
+                    "y": 140
                 },
                 {
                     "id": "ys0CVedHirZ",
@@ -1158,7 +1169,7 @@
                     "width": 58,
                     "height": 20,
                     "x": 0,
-                    "y": 140
+                    "y": 160
                 },
                 {
                     "id": "KI0C90Ol10x",
@@ -1169,7 +1180,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 160
+                    "y": 180
                 },
                 {
                     "id": "uYY7v977Ubm",
@@ -1180,7 +1191,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 160
+                    "y": 180
                 },
                 {
                     "id": "qUqsDmtiBLF",
@@ -1191,7 +1202,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 180
+                    "y": 200
                 },
                 {
                     "id": "mwMpIdPdu8H",
@@ -1202,7 +1213,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 180
+                    "y": 200
                 }
             ],
             "publicAccess": "--------",
@@ -2717,6 +2728,189 @@
                         },
                         {
                             "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "S2kJHgM41El",
+            "type": "LINE",
+            "name": "12345en - MyProject - Target vs Actual - People - Line Chart - Male Only",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
+            "filters": [
+                {
+                    "id": "ou"
+                },
+                {
+                    "id": "Kyg1O6YEGa9",
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
                         }
                     ]
                 },

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1554,9 +1554,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -1565,18 +1563,13 @@
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou"
-            ],
+            "filterDimensions": ["dx", "ou"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1694,9 +1687,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -1735,20 +1726,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1880,25 +1864,19 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2004,9 +1982,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -2045,20 +2021,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2184,17 +2153,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2215,10 +2180,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2339,18 +2301,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "pe",
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2386,11 +2343,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2516,17 +2469,13 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "pe"
@@ -2547,10 +2496,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2656,9 +2602,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -2694,11 +2638,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
@@ -2719,10 +2659,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2860,17 +2797,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2879,10 +2812,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3000,9 +2930,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3038,11 +2966,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3051,10 +2975,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3198,9 +3119,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3229,11 +3148,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3242,10 +3157,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3386,9 +3298,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3417,11 +3327,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3430,10 +3336,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3574,9 +3477,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3605,11 +3506,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3618,10 +3515,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3773,9 +3667,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3804,11 +3696,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3817,10 +3705,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3955,25 +3840,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "sharing": {
                 "public": "--------",
@@ -4066,25 +3945,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "sharing": {
                 "public": "--------",
@@ -4170,25 +4043,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "sharing": {
                 "public": "--------",
@@ -4280,9 +4147,7 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
@@ -4296,18 +4161,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4422,9 +4282,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
@@ -4441,19 +4299,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4557,25 +4409,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "sharing": {
                 "public": "--------",
@@ -4705,9 +4551,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "pe"
@@ -4729,19 +4573,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": [
-                "ou"
-            ],
+            "rowDimensions": ["ou"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4854,9 +4692,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "pe"
@@ -4870,18 +4706,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["pe", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": [
-                "ou"
-            ],
+            "rowDimensions": ["ou"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4996,9 +4827,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5020,19 +4849,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "uSMHdwhxFSV",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["ou", "uSMHdwhxFSV", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5139,9 +4962,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5155,18 +4976,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["ou", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5294,17 +5110,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -5340,11 +5152,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5508,9 +5316,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5546,11 +5352,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "code": "ACTUAL_TARGET",
@@ -5571,10 +5373,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "GIIHAr9BzzO",
-                "pe"
-            ],
+            "rowDimensions": ["GIIHAr9BzzO", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5733,17 +5532,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -5764,10 +5559,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5900,17 +5692,13 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "code": "ACTUAL_TARGET",
@@ -5931,10 +5719,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "GIIHAr9BzzO",
-                "pe"
-            ],
+            "rowDimensions": ["GIIHAr9BzzO", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6157,9 +5942,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
+            "columnDimensions": ["uSMHdwhxFSV"],
             "filters": [
                 {
                     "id": "ou"
@@ -6168,18 +5951,13 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
+            "filterDimensions": ["ou", "pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6376,25 +6154,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "sharing": {
                 "public": "--------",
@@ -6612,18 +6384,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "pe",
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -6659,11 +6426,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6888,17 +6651,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -6919,10 +6678,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7139,9 +6895,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7177,11 +6931,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7202,10 +6952,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7430,17 +7177,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -7461,10 +7204,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7615,9 +7355,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7639,11 +7377,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7664,10 +7398,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7838,9 +7569,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7862,11 +7591,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7887,10 +7612,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -8061,9 +7783,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -8085,11 +7805,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -8110,10 +7826,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -8284,9 +7997,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -8308,11 +8019,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -8333,10 +8040,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1029,10 +1029,10 @@
                     "y": 20
                 },
                 {
-                    "id": "Ka4yijY2Vhl",
-                    "type": "REPORT_TABLE",
+                    "id": "imK8xQLwwYX",
+                    "type": "CHART",
                     "visualization": {
-                        "id": "i07AWJAND8a"
+                        "id": "uYWdSMZQ1LH"
                     },
                     "width": 29,
                     "height": 20,
@@ -1040,103 +1040,15 @@
                     "y": 20
                 },
                 {
-                    "id": "m4LaU9HizHi",
+                    "id": "Ka4yijY2Vhl",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "iOk52Z42bjp"
+                        "id": "i07AWJAND8a"
                     },
                     "width": 29,
                     "height": 20,
                     "x": 0,
                     "y": 40
-                },
-                {
-                    "id": "i66m5HwnH6v",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "a46jcQ65Axt"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 29,
-                    "y": 40
-                },
-                {
-                    "id": "a4GacNVWHLX",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "GA87u7JwgSK"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 0,
-                    "y": 60
-                },
-                {
-                    "id": "KYcDaXAZa1q",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "KiUTxsMMYde"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 29,
-                    "y": 60
-                },
-                {
-                    "id": "a6cSVlR6bSj",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "GkoTRBEmIQt"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 0,
-                    "y": 80
-                },
-                {
-                    "id": "W4DOghdXUmp",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "S2kJHgM41El"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 29,
-                    "y": 80
-                },
-                {
-                    "id": "OgO4mL6ovvU",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "KasxZ8vT1n0"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 0,
-                    "y": 100
-                },
-                {
-                    "id": "K2amO1SBZFm",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "W2SCFrHCiEm"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 29,
-                    "y": 100
-                },
-                {
-                    "id": "GW6MALzFIVR",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "OuKm5zK7l53"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 0,
-                    "y": 120
                 },
                 {
                     "id": "yWGKgz9vaOh",
@@ -1147,28 +1059,105 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 120
+                    "y": 40
                 },
                 {
-                    "id": "ywvTGMsKdwL",
-                    "type": "REPORT_TABLE",
+                    "id": "i66m5HwnH6v",
+                    "type": "CHART",
                     "visualization": {
-                        "id": "SQSYgZjfA3z"
+                        "id": "a46jcQ65Axt"
                     },
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 140
+                    "y": 60
                 },
                 {
-                    "id": "qMSWdZHPjyN",
-                    "type": "REPORT_TABLE",
+                    "id": "a4GacNVWHLX",
+                    "type": "CHART",
                     "visualization": {
-                        "id": "aeGIpbJkZAX"
+                        "id": "GA87u7JwgSK"
                     },
                     "width": 29,
                     "height": 20,
                     "x": 29,
+                    "y": 60
+                },
+                {
+                    "id": "KYcDaXAZa1q",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "KiUTxsMMYde"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 80
+                },
+                {
+                    "id": "a6cSVlR6bSj",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "GkoTRBEmIQt"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 80
+                },
+                {
+                    "id": "W4DOghdXUmp",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "S2kJHgM41El"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 100
+                },
+                {
+                    "id": "OgO4mL6ovvU",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "KasxZ8vT1n0"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 100
+                },
+                {
+                    "id": "K2amO1SBZFm",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "W2SCFrHCiEm"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 120
+                },
+                {
+                    "id": "GW6MALzFIVR",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "OuKm5zK7l53"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 29,
+                    "y": 120
+                },
+                {
+                    "id": "m4LaU9HizHi",
+                    "type": "REPORT_TABLE",
+                    "visualization": {
+                        "id": "iOk52Z42bjp"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
                     "y": 140
                 },
                 {
@@ -1179,30 +1168,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
-                    "y": 160
-                },
-                {
-                    "id": "mgwFIMjbsdw",
-                    "type": "REPORT_TABLE",
-                    "visualization": {
-                        "id": "GEe8ZzUkVwG"
-                    },
-                    "width": 29,
-                    "height": 20,
                     "x": 29,
-                    "y": 160
-                },
-                {
-                    "id": "ys0CVedHirZ",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "uG9C9z46CNK"
-                    },
-                    "width": 58,
-                    "height": 20,
-                    "x": 0,
-                    "y": 180
+                    "y": 140
                 },
                 {
                     "id": "KI0C90Ol10x",
@@ -1213,7 +1180,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 200
+                    "y": 160
                 },
                 {
                     "id": "uYY7v977Ubm",
@@ -1224,7 +1191,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 200
+                    "y": 160
                 },
                 {
                     "id": "qUqsDmtiBLF",
@@ -1235,7 +1202,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 220
+                    "y": 180
                 },
                 {
                     "id": "mwMpIdPdu8H",
@@ -1246,7 +1213,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 220
+                    "y": 180
                 }
             ],
             "publicAccess": "--------",
@@ -1404,17 +1371,6 @@
                     "y": 60
                 },
                 {
-                    "id": "CkcoElgGMuu",
-                    "type": "CHART",
-                    "visualization": {
-                        "id": "CYYNLjxd96q"
-                    },
-                    "width": 58,
-                    "height": 20,
-                    "x": 0,
-                    "y": 80
-                },
-                {
                     "id": "GqqyIiwIxog",
                     "type": "CHART",
                     "visualization": {
@@ -1422,8 +1378,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
-                    "y": 100
+                    "x": 29,
+                    "y": 60
                 },
                 {
                     "id": "mCeCHYX6DOG",
@@ -1433,8 +1389,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 100
+                    "x": 0,
+                    "y": 80
                 },
                 {
                     "id": "O8EPBVIg4zK",
@@ -1444,8 +1400,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
-                    "y": 120
+                    "x": 29,
+                    "y": 80
                 },
                 {
                     "id": "OI8TXjJJwfS",
@@ -1455,8 +1411,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 120
+                    "x": 0,
+                    "y": 100
                 }
             ],
             "publicAccess": "--------",
@@ -1552,7 +1508,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1561,13 +1519,18 @@
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["dx", "ou"],
+            "filterDimensions": [
+                "dx",
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1680,7 +1643,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "dx"
@@ -1719,13 +1684,20 @@
                     ]
                 }
             ],
-            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "dx",
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1852,19 +1824,25 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1876,6 +1854,187 @@
                         },
                         {
                             "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
+            "id": "uYWdSMZQ1LH",
+            "type": "COLUMN",
+            "name": "12345en - MyProject - MER - Target vs Actual - People - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
+            "filters": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "ou"
+                },
+                {
+                    "code": "GENDER",
+                    "id": "Kyg1O6YEGa9",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "MALE",
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "code": "FEMALE",
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
+            "filterDimensions": [
+                "dx",
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
+            "rows": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": [
+                "pe"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
                         }
                     ]
                 }
@@ -1959,13 +2118,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -1986,7 +2149,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2025,9 +2191,9 @@
             ]
         },
         {
-            "id": "iOk52Z42bjp",
+            "id": "iqqgnCj9DQj",
             "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Achieved to date (%) - Benefits",
+            "name": "12345en - MyProject - Target vs Actual - People",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -2039,15 +2205,21 @@
             "digitGroupSeparator": "SPACE",
             "dataDimensionItems": [
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "K6mAC5SiO29"
                     }
                 },
                 {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "ik0ICagvIjm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "GQyudNlGzkI"
                     }
                 }
             ],
@@ -2079,22 +2251,116 @@
             "columns": [
                 {
                     "id": "pe"
+                },
+                {
+                    "code": "GENDER",
+                    "id": "Kyg1O6YEGa9",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "MALE",
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "code": "FEMALE",
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe",
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "code": "NEW_RETURNING",
+                    "id": "uSMHdwhxFSV",
+                    "dataDimensionType": "DISAGGREGATION",
+                    "categoryOptions": [
+                        {
+                            "code": "NEW",
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "code": "RETURNING",
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
                 }
             ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "Kyg1O6YEGa9"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                },
+                {
+                    "category": {
+                        "id": "uSMHdwhxFSV"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO"
+                        }
+                    ]
+                }
+            ],
             "publicAccess": "--------",
             "externalAccess": false,
             "userAccesses": [
@@ -2115,11 +2381,7 @@
                     "displayName": "Data Management Admin",
                     "access": "rw------"
                 }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
+            ]
         },
         {
             "id": "a46jcQ65Axt",
@@ -2178,13 +2440,17 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "pe"
@@ -2205,7 +2471,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["pe", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2306,7 +2575,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2342,7 +2613,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "pe"
@@ -2363,7 +2638,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["pe", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2496,13 +2774,17 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2511,7 +2793,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2624,7 +2909,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2660,7 +2947,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2669,7 +2960,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2808,7 +3102,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -2837,7 +3133,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -2846,7 +3146,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2982,7 +3285,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3011,7 +3316,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3020,7 +3329,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3156,7 +3468,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3185,7 +3499,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3194,7 +3512,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3341,7 +3662,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["GIIHAr9BzzO"],
+            "columnDimensions": [
+                "GIIHAr9BzzO"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -3370,7 +3693,11 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "Kyg1O6YEGa9",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -3379,7 +3706,10 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["dx", "pe"],
+            "rowDimensions": [
+                "dx",
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3452,315 +3782,9 @@
             ]
         },
         {
-            "id": "iqqgnCj9DQj",
+            "id": "iOk52Z42bjp",
             "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Target vs Actual - People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "K6mAC5SiO29"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "ik0ICagvIjm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "GQyudNlGzkI"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                },
-                {
-                    "code": "GENDER",
-                    "id": "Kyg1O6YEGa9",
-                    "dataDimensionType": "DISAGGREGATION",
-                    "categoryOptions": [
-                        {
-                            "code": "MALE",
-                            "id": "qk2FihwV6IL"
-                        },
-                        {
-                            "code": "FEMALE",
-                            "id": "yW2hYVS3S4u"
-                        }
-                    ]
-                }
-            ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
-            "filters": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "filterDimensions": ["ou"],
-            "rows": [
-                {
-                    "id": "dx"
-                },
-                {
-                    "code": "ACTUAL_TARGET",
-                    "id": "GIIHAr9BzzO",
-                    "dataDimensionType": "ATTRIBUTE",
-                    "categoryOptions": [
-                        {
-                            "code": "TARGET",
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "code": "ACTUAL",
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                },
-                {
-                    "code": "NEW_RETURNING",
-                    "id": "uSMHdwhxFSV",
-                    "dataDimensionType": "DISAGGREGATION",
-                    "categoryOptions": [
-                        {
-                            "code": "NEW",
-                            "id": "KiK0FMExoqh"
-                        },
-                        {
-                            "code": "RETURNING",
-                            "id": "a6AJLXQy8vO"
-                        }
-                    ]
-                }
-            ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "Kyg1O6YEGa9"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "qk2FihwV6IL"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u"
-                        }
-                    ]
-                },
-                {
-                    "category": {
-                        "id": "GIIHAr9BzzO"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                },
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        },
-                        {
-                            "id": "a6AJLXQy8vO"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ]
-        },
-        {
-            "id": "SQSYgZjfA3z",
-            "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Achieved total to date (%) - People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": false,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "uSMHdwhxFSV",
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "columnDimensions": ["uSMHdwhxFSV"],
-            "filters": [
-                {
-                    "id": "ou"
-                },
-                {
-                    "id": "pe"
-                }
-            ],
-            "filterDimensions": ["ou", "pe"],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "aeGIpbJkZAX",
-            "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Achieved (%) - Benefits",
+            "name": "12345en - MyProject - Achieved to date (%) - Benefits",
             "numberType": "VALUE",
             "legendDisplayStyle": "FILL",
             "rowSubTotals": true,
@@ -3814,19 +3838,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3917,19 +3947,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3956,239 +3992,6 @@
                 "code": "ACTUAL_TARGET_ACHIEVED",
                 "id": "yoAt108kUFm"
             }
-        },
-        {
-            "id": "GEe8ZzUkVwG",
-            "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Achieved total (%) - People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": false,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "uSMHdwhxFSV",
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "columnDimensions": ["uSMHdwhxFSV"],
-            "filters": [
-                {
-                    "id": "ou"
-                },
-                {
-                    "id": "pe"
-                }
-            ],
-            "filterDimensions": ["ou", "pe"],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
-        },
-        {
-            "id": "uG9C9z46CNK",
-            "type": "COLUMN",
-            "name": "12345en - MyProject - Achieved monthly (%)",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                }
-            ],
-            "columnDimensions": ["pe"],
-            "filters": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "filterDimensions": ["ou"],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ]
         },
         {
             "id": "qmsj4FqnVPX",
@@ -4247,19 +4050,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4346,7 +4155,9 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -4360,13 +4171,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4476,7 +4292,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -4493,13 +4311,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4598,19 +4422,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4735,7 +4565,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -4757,13 +4589,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": ["ou"],
+            "rowDimensions": [
+                "ou"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4871,7 +4709,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -4885,13 +4725,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "pe",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": ["ou"],
+            "rowDimensions": [
+                "ou"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5001,7 +4846,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -5023,13 +4870,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "uSMHdwhxFSV", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "ou",
+                "uSMHdwhxFSV",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5131,7 +4984,9 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": ["dx"],
+            "columnDimensions": [
+                "dx"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -5145,13 +5000,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "GIIHAr9BzzO"],
+            "filterDimensions": [
+                "ou",
+                "GIIHAr9BzzO"
+            ],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": ["pe"],
+            "rowDimensions": [
+                "pe"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5322,13 +5182,17 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -5349,7 +5213,10 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5576,13 +5443,18 @@
                     ]
                 }
             ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "pe",
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
@@ -5618,7 +5490,11 @@
                     ]
                 }
             ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
+            "rowDimensions": [
+                "dx",
+                "GIIHAr9BzzO",
+                "uSMHdwhxFSV"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5838,19 +5714,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6057,7 +5939,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -6066,13 +5950,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6267,19 +6156,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6481,19 +6376,25 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": ["pe"],
+            "columnDimensions": [
+                "pe"
+            ],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": ["ou"],
+            "filterDimensions": [
+                "ou"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6700,7 +6601,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["uSMHdwhxFSV"],
+            "columnDimensions": [
+                "uSMHdwhxFSV"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -6709,13 +6612,18 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["ou", "pe"],
+            "filterDimensions": [
+                "ou",
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6753,264 +6661,6 @@
                 "code": "ACTUAL_TARGET_ACHIEVED",
                 "id": "yoAt108kUFm"
             }
-        },
-        {
-            "id": "CYYNLjxd96q",
-            "type": "COLUMN",
-            "name": "Award Number 12345 - Achieved monthly (%)",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qu0x94utOgv"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qQsafE8eZQt"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "isKcihOpMrF"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "OOIDqW7eQqr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "CqURW24bmHJ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "iewd6jLYV4H"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K6ipXoSOmt2"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qgGwMTqEq4d"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "aOALuHaoaEQ"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "yeQN47GFqwM"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K2ADN2EmEmr"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "qW6b6ZRfXA5"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "m68LzR6ho7V"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "KOKIhtZYDOh"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eYmeRzhBFV4"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "u404ICrBKj3"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "K4sH0aQDdeL"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                }
-            ],
-            "columnDimensions": ["pe"],
-            "filters": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "filterDimensions": ["ou"],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ]
         },
         {
             "id": "Gi2PegQJhbu",
@@ -7168,19 +6818,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -7378,7 +7034,9 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
@@ -7392,13 +7050,18 @@
                     ]
                 }
             ],
-            "filterDimensions": ["pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7619,7 +7282,9 @@
                     ]
                 }
             ],
-            "columnDimensions": ["Kyg1O6YEGa9"],
+            "columnDimensions": [
+                "Kyg1O6YEGa9"
+            ],
             "filters": [
                 {
                     "id": "ou"
@@ -7636,13 +7301,19 @@
                     ]
                 }
             ],
-            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
+            "filterDimensions": [
+                "ou",
+                "pe",
+                "uSMHdwhxFSV"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7804,19 +7475,25 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": ["ou"],
+            "columnDimensions": [
+                "ou"
+            ],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": ["pe"],
+            "filterDimensions": [
+                "pe"
+            ],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": ["dx"],
+            "rowDimensions": [
+                "dx"
+            ],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -996,6 +996,17 @@
             "name": "12345en - MyProject",
             "dashboardItems": [
                 {
+                    "id": "uOsjh5OmILO",
+                    "type": "CHART",
+                    "visualization": {
+                        "id": "ywQZlYBN4nN"
+                    },
+                    "width": 29,
+                    "height": 20,
+                    "x": 0,
+                    "y": 0
+                },
+                {
                     "id": "Ka4yijY2Vhl",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1003,7 +1014,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 0
                 },
                 {
@@ -1014,8 +1025,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 0
+                    "x": 0,
+                    "y": 20
                 },
                 {
                     "id": "y2G8oh7xQBm",
@@ -1025,7 +1036,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 20
                 },
                 {
@@ -1036,8 +1047,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 20
+                    "x": 0,
+                    "y": 40
                 },
                 {
                     "id": "ywvTGMsKdwL",
@@ -1047,7 +1058,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 40
                 },
                 {
@@ -1058,8 +1069,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 40
+                    "x": 0,
+                    "y": 60
                 },
                 {
                     "id": "uyoJujQVRjE",
@@ -1069,7 +1080,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
+                    "x": 29,
                     "y": 60
                 },
                 {
@@ -1080,8 +1091,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
-                    "y": 60
+                    "x": 0,
+                    "y": 80
                 },
                 {
                     "id": "ys0CVedHirZ",
@@ -1092,7 +1103,7 @@
                     "width": 58,
                     "height": 20,
                     "x": 0,
-                    "y": 80
+                    "y": 100
                 },
                 {
                     "id": "KI0C90Ol10x",
@@ -1103,7 +1114,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 100
+                    "y": 120
                 },
                 {
                     "id": "uYY7v977Ubm",
@@ -1114,7 +1125,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 100
+                    "y": 120
                 },
                 {
                     "id": "qUqsDmtiBLF",
@@ -1125,7 +1136,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 0,
-                    "y": 120
+                    "y": 140
                 },
                 {
                     "id": "mwMpIdPdu8H",
@@ -1136,7 +1147,7 @@
                     "width": 29,
                     "height": 20,
                     "x": 29,
-                    "y": 120
+                    "y": 140
                 }
             ],
             "publicAccess": "--------",
@@ -1384,6 +1395,128 @@
         }
     ],
     "visualizations": [
+        {
+            "id": "ywQZlYBN4nN",
+            "type": "COLUMN",
+            "name": "12345en - MyProject - Target vs Actual - Benefits - Column Chart",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WS8XV4WWPE7"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
+            "filters": [
+                {
+                    "id": "dx"
+                },
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": ["dx", "ou"],
+            "rows": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "rowDimensions": ["pe"],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
         {
             "id": "i07AWJAND8a",
             "type": "PIVOT_TABLE",

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1541,9 +1541,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -1552,18 +1550,13 @@
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou"
-            ],
+            "filterDimensions": ["dx", "ou"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1676,9 +1669,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -1717,20 +1708,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1857,25 +1841,19 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -1976,9 +1954,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "dx"
@@ -2017,20 +1993,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "dx",
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["dx", "ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2151,17 +2120,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2182,10 +2147,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2301,18 +2263,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "pe",
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2348,11 +2305,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2473,17 +2426,13 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "pe"
@@ -2504,10 +2453,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2608,9 +2554,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -2646,11 +2590,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "pe"
@@ -2671,10 +2611,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2807,17 +2744,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -2826,10 +2759,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -2942,9 +2872,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -2980,11 +2908,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -2993,10 +2917,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3135,9 +3056,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3166,11 +3085,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3179,10 +3094,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3318,9 +3230,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3349,11 +3259,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3362,10 +3268,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3501,9 +3404,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3532,11 +3433,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3545,10 +3442,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3695,9 +3589,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "GIIHAr9BzzO"
-            ],
+            "columnDimensions": ["GIIHAr9BzzO"],
             "filters": [
                 {
                     "id": "ou"
@@ -3726,11 +3618,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -3739,10 +3627,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "pe"
-            ],
+            "rowDimensions": ["dx", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -3871,25 +3756,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -3980,25 +3859,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4083,25 +3956,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4188,9 +4055,7 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
@@ -4204,18 +4069,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4325,9 +4185,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
@@ -4344,19 +4202,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "pe", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4455,25 +4307,19 @@
                     "id": "ou"
                 }
             ],
-            "columnDimensions": [
-                "ou"
-            ],
+            "columnDimensions": ["ou"],
             "filters": [
                 {
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "pe"
-            ],
+            "filterDimensions": ["pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -4598,9 +4444,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "pe"
@@ -4622,19 +4466,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "uSMHdwhxFSV",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["pe", "uSMHdwhxFSV", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": [
-                "ou"
-            ],
+            "rowDimensions": ["ou"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4742,9 +4580,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "pe"
@@ -4758,18 +4594,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "pe",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["pe", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "ou"
                 }
             ],
-            "rowDimensions": [
-                "ou"
-            ],
+            "rowDimensions": ["ou"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -4879,9 +4710,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -4903,19 +4732,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "uSMHdwhxFSV",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["ou", "uSMHdwhxFSV", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5017,9 +4840,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5033,18 +4854,13 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "GIIHAr9BzzO"
-            ],
+            "filterDimensions": ["ou", "GIIHAr9BzzO"],
             "rows": [
                 {
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "pe"
-            ],
+            "rowDimensions": ["pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5167,17 +4983,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -5213,11 +5025,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5376,9 +5184,7 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
@@ -5414,11 +5220,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "code": "ACTUAL_TARGET",
@@ -5439,10 +5241,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "GIIHAr9BzzO",
-                "pe"
-            ],
+            "rowDimensions": ["GIIHAr9BzzO", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5596,17 +5395,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -5627,10 +5422,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -5758,17 +5550,13 @@
                     "id": "dx"
                 }
             ],
-            "columnDimensions": [
-                "dx"
-            ],
+            "columnDimensions": ["dx"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "code": "ACTUAL_TARGET",
@@ -5789,10 +5577,7 @@
                     "id": "pe"
                 }
             ],
-            "rowDimensions": [
-                "GIIHAr9BzzO",
-                "pe"
-            ],
+            "rowDimensions": ["GIIHAr9BzzO", "pe"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6009,9 +5794,7 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "uSMHdwhxFSV"
-            ],
+            "columnDimensions": ["uSMHdwhxFSV"],
             "filters": [
                 {
                     "id": "ou"
@@ -6020,18 +5803,13 @@
                     "id": "pe"
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "pe"
-            ],
+            "filterDimensions": ["ou", "pe"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6226,25 +6004,19 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
                 }
             ],
-            "rowDimensions": [
-                "dx"
-            ],
+            "rowDimensions": ["dx"],
             "categoryDimensions": [],
             "publicAccess": "--------",
             "externalAccess": false,
@@ -6461,18 +6233,13 @@
                     ]
                 }
             ],
-            "columnDimensions": [
-                "pe",
-                "Kyg1O6YEGa9"
-            ],
+            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -6508,11 +6275,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO",
-                "uSMHdwhxFSV"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6732,17 +6495,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -6763,10 +6522,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -6978,9 +6734,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7016,11 +6770,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7041,10 +6791,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7264,17 +7011,13 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
                 }
             ],
-            "filterDimensions": [
-                "ou"
-            ],
+            "filterDimensions": ["ou"],
             "rows": [
                 {
                     "id": "dx"
@@ -7295,10 +7038,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7444,9 +7184,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7468,11 +7206,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7493,10 +7227,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7662,9 +7393,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7686,11 +7415,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7711,10 +7436,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -7880,9 +7602,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -7904,11 +7624,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -7929,10 +7645,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {
@@ -8098,9 +7811,7 @@
                     "id": "pe"
                 }
             ],
-            "columnDimensions": [
-                "pe"
-            ],
+            "columnDimensions": ["pe"],
             "filters": [
                 {
                     "id": "ou"
@@ -8122,11 +7833,7 @@
                     ]
                 }
             ],
-            "filterDimensions": [
-                "ou",
-                "Kyg1O6YEGa9",
-                "uSMHdwhxFSV"
-            ],
+            "filterDimensions": ["ou", "Kyg1O6YEGa9", "uSMHdwhxFSV"],
             "rows": [
                 {
                     "id": "dx"
@@ -8147,10 +7854,7 @@
                     ]
                 }
             ],
-            "rowDimensions": [
-                "dx",
-                "GIIHAr9BzzO"
-            ],
+            "rowDimensions": ["dx", "GIIHAr9BzzO"],
             "categoryDimensions": [
                 {
                     "category": {

--- a/src/models/__tests__/data/project-db-metadata.json
+++ b/src/models/__tests__/data/project-db-metadata.json
@@ -1040,10 +1040,10 @@
                     "y": 20
                 },
                 {
-                    "id": "yWGKgz9vaOh",
+                    "id": "m4LaU9HizHi",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "iqqgnCj9DQj"
+                        "id": "iOk52Z42bjp"
                     },
                     "width": 29,
                     "height": 20,
@@ -1051,10 +1051,10 @@
                     "y": 40
                 },
                 {
-                    "id": "y2G8oh7xQBm",
-                    "type": "REPORT_TABLE",
+                    "id": "i66m5HwnH6v",
+                    "type": "CHART",
                     "visualization": {
-                        "id": "GycLEG8dPPO"
+                        "id": "a46jcQ65Axt"
                     },
                     "width": 29,
                     "height": 20,
@@ -1062,10 +1062,10 @@
                     "y": 40
                 },
                 {
-                    "id": "m4LaU9HizHi",
+                    "id": "yWGKgz9vaOh",
                     "type": "REPORT_TABLE",
                     "visualization": {
-                        "id": "iOk52Z42bjp"
+                        "id": "iqqgnCj9DQj"
                     },
                     "width": 29,
                     "height": 20,
@@ -1272,17 +1272,6 @@
                     "y": 0
                 },
                 {
-                    "id": "K0YRx2HGCs5",
-                    "type": "REPORT_TABLE",
-                    "visualization": {
-                        "id": "ayOoqqk9Rnb"
-                    },
-                    "width": 29,
-                    "height": 20,
-                    "x": 0,
-                    "y": 20
-                },
-                {
                     "id": "O0uabsxLqGS",
                     "type": "REPORT_TABLE",
                     "visualization": {
@@ -1290,7 +1279,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
+                    "x": 0,
                     "y": 20
                 },
                 {
@@ -1301,8 +1290,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
-                    "y": 40
+                    "x": 29,
+                    "y": 20
                 },
                 {
                     "id": "iIyADNFfXEV",
@@ -1312,7 +1301,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
+                    "x": 0,
                     "y": 40
                 },
                 {
@@ -1323,8 +1312,8 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 0,
-                    "y": 60
+                    "x": 29,
+                    "y": 40
                 },
                 {
                     "id": "yseGHIbXcNQ",
@@ -1334,7 +1323,7 @@
                     },
                     "width": 29,
                     "height": 20,
-                    "x": 29,
+                    "x": 0,
                     "y": 60
                 },
                 {
@@ -1959,6 +1948,225 @@
             ]
         },
         {
+            "id": "iOk52Z42bjp",
+            "type": "PIVOT_TABLE",
+            "name": "12345en - MyProject - Achieved to date (%) - Benefits",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "eCufXa6RkTm"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "INDICATOR",
+                    "indicator": {
+                        "id": "i01veyO4Cuw"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "pe"
+                }
+            ],
+            "columnDimensions": ["pe"],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": ["ou"],
+            "rows": [
+                {
+                    "id": "dx"
+                }
+            ],
+            "rowDimensions": ["dx"],
+            "categoryDimensions": [],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ],
+            "legendSet": {
+                "code": "ACTUAL_TARGET_ACHIEVED",
+                "id": "yoAt108kUFm"
+            }
+        },
+        {
+            "id": "a46jcQ65Axt",
+            "type": "COLUMN",
+            "name": "12345en - MyProject - Target vs Actual - Benefits - Column Chart Disaggregated By Indicator",
+            "numberType": "VALUE",
+            "legendDisplayStyle": "FILL",
+            "rowSubTotals": true,
+            "showDimensionLabels": true,
+            "showData": true,
+            "aggregationType": "DEFAULT",
+            "legendDisplayStrategy": "FIXED",
+            "rowTotals": true,
+            "digitGroupSeparator": "SPACE",
+            "dataDimensionItems": [
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "WS8XV4WWPE7"
+                    }
+                },
+                {
+                    "dataDimensionItemType": "DATA_ELEMENT",
+                    "dataElement": {
+                        "id": "yMqK9DKbA3X"
+                    }
+                }
+            ],
+            "organisationUnits": [
+                {
+                    "id": "WGC0DJ0YSis"
+                }
+            ],
+            "periods": [
+                {
+                    "id": "201810"
+                },
+                {
+                    "id": "201811"
+                },
+                {
+                    "id": "201812"
+                },
+                {
+                    "id": "201901"
+                },
+                {
+                    "id": "201902"
+                },
+                {
+                    "id": "201903"
+                }
+            ],
+            "columns": [
+                {
+                    "id": "dx"
+                }
+            ],
+            "columnDimensions": ["dx"],
+            "filters": [
+                {
+                    "id": "ou"
+                }
+            ],
+            "filterDimensions": ["ou"],
+            "rows": [
+                {
+                    "id": "pe"
+                },
+                {
+                    "code": "ACTUAL_TARGET",
+                    "id": "GIIHAr9BzzO",
+                    "dataDimensionType": "ATTRIBUTE",
+                    "categoryOptions": [
+                        {
+                            "code": "TARGET",
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "code": "ACTUAL",
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "rowDimensions": ["pe", "GIIHAr9BzzO"],
+            "categoryDimensions": [
+                {
+                    "category": {
+                        "id": "GIIHAr9BzzO"
+                    },
+                    "categoryOptions": [
+                        {
+                            "id": "imyqCWQ229K"
+                        },
+                        {
+                            "id": "eWeQoOlAcxV"
+                        }
+                    ]
+                }
+            ],
+            "publicAccess": "--------",
+            "externalAccess": false,
+            "userAccesses": [
+                {
+                    "id": "M5zQapPyTZI",
+                    "displayName": "admin admin",
+                    "access": "rw------"
+                }
+            ],
+            "userGroupAccesses": [
+                {
+                    "id": "ywuI2WspUUG",
+                    "displayName": "System Admin",
+                    "access": "rw------"
+                },
+                {
+                    "id": "mKKNXzeIAJs",
+                    "displayName": "Data Management Admin",
+                    "access": "rw------"
+                }
+            ]
+        },
+        {
             "id": "iqqgnCj9DQj",
             "type": "PIVOT_TABLE",
             "name": "12345en - MyProject - Target vs Actual - People",
@@ -2141,277 +2349,6 @@
                     "access": "rw------"
                 }
             ]
-        },
-        {
-            "id": "GycLEG8dPPO",
-            "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Target vs Actual - Unique People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "K6mAC5SiO29"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "ik0ICagvIjm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "GQyudNlGzkI"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                },
-                {
-                    "code": "GENDER",
-                    "id": "Kyg1O6YEGa9",
-                    "dataDimensionType": "DISAGGREGATION",
-                    "categoryOptions": [
-                        {
-                            "code": "MALE",
-                            "id": "qk2FihwV6IL"
-                        },
-                        {
-                            "code": "FEMALE",
-                            "id": "yW2hYVS3S4u"
-                        }
-                    ]
-                }
-            ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
-            "filters": [
-                {
-                    "id": "ou"
-                },
-                {
-                    "id": "uSMHdwhxFSV",
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "filterDimensions": ["ou", "uSMHdwhxFSV"],
-            "rows": [
-                {
-                    "id": "dx"
-                },
-                {
-                    "code": "ACTUAL_TARGET",
-                    "id": "GIIHAr9BzzO",
-                    "dataDimensionType": "ATTRIBUTE",
-                    "categoryOptions": [
-                        {
-                            "code": "TARGET",
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "code": "ACTUAL",
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                }
-            ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "Kyg1O6YEGa9"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "qk2FihwV6IL"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u"
-                        }
-                    ]
-                },
-                {
-                    "category": {
-                        "id": "GIIHAr9BzzO"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                },
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ]
-        },
-        {
-            "id": "iOk52Z42bjp",
-            "type": "PIVOT_TABLE",
-            "name": "12345en - MyProject - Achieved to date (%) - Benefits",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "eCufXa6RkTm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "INDICATOR",
-                    "indicator": {
-                        "id": "i01veyO4Cuw"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                }
-            ],
-            "columnDimensions": ["pe"],
-            "filters": [
-                {
-                    "id": "ou"
-                }
-            ],
-            "filterDimensions": ["ou"],
-            "rows": [
-                {
-                    "id": "dx"
-                }
-            ],
-            "rowDimensions": ["dx"],
-            "categoryDimensions": [],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ],
-            "legendSet": {
-                "code": "ACTUAL_TARGET_ACHIEVED",
-                "id": "yoAt108kUFm"
-            }
         },
         {
             "id": "SQSYgZjfA3z",
@@ -4434,291 +4371,6 @@
                         },
                         {
                             "id": "a6AJLXQy8vO"
-                        }
-                    ]
-                }
-            ],
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rw------"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rw------"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rw------"
-                }
-            ]
-        },
-        {
-            "id": "ayOoqqk9Rnb",
-            "type": "PIVOT_TABLE",
-            "name": "Award Number 12345 - Target vs Actual - Unique People",
-            "numberType": "VALUE",
-            "legendDisplayStyle": "FILL",
-            "rowSubTotals": true,
-            "showDimensionLabels": true,
-            "showData": true,
-            "aggregationType": "DEFAULT",
-            "legendDisplayStrategy": "FIXED",
-            "rowTotals": true,
-            "digitGroupSeparator": "SPACE",
-            "dataDimensionItems": [
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "SQy5q6kCYI1"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "iYEDR850FFL"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "qkyeCTJHU2d"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "eAkVLI8mKBa"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "Kg29718LQHl"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "KKmUWsn19fq"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "iCKxYSFIlcu"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "qAM1NbCbS9G"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "K6mAC5SiO29"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "ik0ICagvIjm"
-                    }
-                },
-                {
-                    "dataDimensionItemType": "DATA_ELEMENT",
-                    "dataElement": {
-                        "id": "GQyudNlGzkI"
-                    }
-                }
-            ],
-            "organisationUnits": [
-                {
-                    "id": "WGC0DJ0YSis"
-                },
-                {
-                    "id": "TvSmIyYcRnd"
-                },
-                {
-                    "id": "cqZ9zQfePzQ"
-                }
-            ],
-            "periods": [
-                {
-                    "id": "201810"
-                },
-                {
-                    "id": "201811"
-                },
-                {
-                    "id": "201812"
-                },
-                {
-                    "id": "201901"
-                },
-                {
-                    "id": "201902"
-                },
-                {
-                    "id": "201903"
-                },
-                {
-                    "id": "201904"
-                },
-                {
-                    "id": "201905"
-                },
-                {
-                    "id": "201906"
-                },
-                {
-                    "id": "201907"
-                },
-                {
-                    "id": "201908"
-                },
-                {
-                    "id": "201909"
-                },
-                {
-                    "id": "201910"
-                },
-                {
-                    "id": "201911"
-                },
-                {
-                    "id": "201912"
-                },
-                {
-                    "id": "202001"
-                },
-                {
-                    "id": "202002"
-                },
-                {
-                    "id": "202003"
-                },
-                {
-                    "id": "202004"
-                },
-                {
-                    "id": "202005"
-                },
-                {
-                    "id": "202006"
-                },
-                {
-                    "id": "202007"
-                },
-                {
-                    "id": "202008"
-                },
-                {
-                    "id": "202009"
-                },
-                {
-                    "id": "202010"
-                }
-            ],
-            "columns": [
-                {
-                    "id": "pe"
-                },
-                {
-                    "code": "GENDER",
-                    "id": "Kyg1O6YEGa9",
-                    "dataDimensionType": "DISAGGREGATION",
-                    "categoryOptions": [
-                        {
-                            "code": "MALE",
-                            "id": "qk2FihwV6IL"
-                        },
-                        {
-                            "code": "FEMALE",
-                            "id": "yW2hYVS3S4u"
-                        }
-                    ]
-                }
-            ],
-            "columnDimensions": ["pe", "Kyg1O6YEGa9"],
-            "filters": [
-                {
-                    "id": "ou"
-                },
-                {
-                    "id": "uSMHdwhxFSV",
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
-                        }
-                    ]
-                }
-            ],
-            "filterDimensions": ["ou", "uSMHdwhxFSV"],
-            "rows": [
-                {
-                    "id": "dx"
-                },
-                {
-                    "code": "ACTUAL_TARGET",
-                    "id": "GIIHAr9BzzO",
-                    "dataDimensionType": "ATTRIBUTE",
-                    "categoryOptions": [
-                        {
-                            "code": "TARGET",
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "code": "ACTUAL",
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                }
-            ],
-            "rowDimensions": ["dx", "GIIHAr9BzzO"],
-            "categoryDimensions": [
-                {
-                    "category": {
-                        "id": "Kyg1O6YEGa9"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "qk2FihwV6IL"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u"
-                        }
-                    ]
-                },
-                {
-                    "category": {
-                        "id": "GIIHAr9BzzO"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "imyqCWQ229K"
-                        },
-                        {
-                            "id": "eWeQoOlAcxV"
-                        }
-                    ]
-                },
-                {
-                    "category": {
-                        "id": "uSMHdwhxFSV"
-                    },
-                    "categoryOptions": [
-                        {
-                            "id": "KiK0FMExoqh"
                         }
                     ]
                 }

--- a/src/models/__tests__/data/project-metadata.json
+++ b/src/models/__tests__/data/project-metadata.json
@@ -16,27 +16,6 @@
         {
             "code": "WGC0DJ0YSis_ACTUAL",
             "id": "CwUxT9UIX3z",
-            "publicAccess": "--------",
-            "externalAccess": false,
-            "userAccesses": [
-                {
-                    "id": "M5zQapPyTZI",
-                    "displayName": "admin admin",
-                    "access": "rwrw----"
-                }
-            ],
-            "userGroupAccesses": [
-                {
-                    "id": "ywuI2WspUUG",
-                    "displayName": "System Admin",
-                    "access": "rwrw----"
-                },
-                {
-                    "id": "mKKNXzeIAJs",
-                    "displayName": "Data Management Admin",
-                    "access": "rwrw----"
-                }
-            ],
             "dataSetElements": [
                 {
                     "dataElement": {
@@ -293,7 +272,30 @@
                     "closingDate": "2019-03-10T00:00:00.000",
                     "openingDate": "2018-10-01T00:00:00.000"
                 }
-            ]
+            ],
+            "sharing": {
+                "public": "--------",
+                "external": false,
+                "users": {
+                    "M5zQapPyTZI": {
+                        "id": "M5zQapPyTZI",
+                        "displayName": "admin admin",
+                        "access": "rwrw----"
+                    }
+                },
+                "userGroups": {
+                    "ywuI2WspUUG": {
+                        "id": "ywuI2WspUUG",
+                        "displayName": "System Admin",
+                        "access": "rwrw----"
+                    },
+                    "mKKNXzeIAJs": {
+                        "id": "mKKNXzeIAJs",
+                        "displayName": "Data Management Admin",
+                        "access": "rwrw----"
+                    }
+                }
+            }
         }
     ]
 }

--- a/src/models/__tests__/mer-data.ts
+++ b/src/models/__tests__/mer-data.ts
@@ -1,5 +1,7 @@
-import MockAdapter from "axios-mock-adapter";
 import { logUnknownRequest } from "../../utils/tests";
+import { getMockApi } from "../../types/d2-api";
+
+type MockAdapter = ReturnType<typeof getMockApi>["mock"];
 
 function mockApiMerDataSets(mock: MockAdapter, orgUnitIds: string[]) {
     mock.onGet("/metadata", {

--- a/src/pages/data-values/DataValues.tsx
+++ b/src/pages/data-values/DataValues.tsx
@@ -12,6 +12,8 @@ import { Config } from "../../models/Config";
 import { link } from "../../utils/form";
 import { useAppHistory } from "../../utils/use-app-history";
 import { generateUrl } from "../../router";
+import { DataSetCustomForm } from "../../data/DataSetCustomForm";
+import { Id } from "../../domain/entities/Ref";
 
 interface DataValuesProps {
     type: DataSetType;
@@ -32,6 +34,10 @@ const DataValues: React.FC<DataValuesProps> = ({ type }) => {
     const { api, config } = useAppContext();
     const appHistory = useAppHistory(generateUrl("projects"));
     const match = useRouteMatch<RouterParams>();
+    const [cfState, setCfState] = useState<GetState<{ customFormId: Id }>>({
+        loading: false,
+        error: "",
+    });
     const [state, setState] = useState<State>({ loading: true });
     const { data, loading, error } = state;
     const translations = getTranslations(type, data?.project);
@@ -41,6 +47,33 @@ const DataValues: React.FC<DataValuesProps> = ({ type }) => {
     useEffect(() => {
         return loadData(projectId, type, api, config, setState);
     }, [api, config, type, projectId]);
+
+    useEffect(() => {
+        if (!state.data?.dataSet) return;
+
+        function generateCustomForm() {
+            if (!state.data?.dataSet) return;
+
+            setCfState({ loading: true });
+
+            new DataSetCustomForm(api)
+                .saveCustomForm(state.data.dataSet.id, state.data.project, type)
+                .then(customFormId => {
+                    if (customFormId) {
+                        setCfState({ data: { customFormId }, loading: false });
+                    }
+                })
+                .catch(() => {
+                    setCfState({
+                        data: undefined,
+                        loading: false,
+                        error: i18n.t("Error generating custom form"),
+                    });
+                });
+        }
+
+        generateCustomForm();
+    }, [api, type, state.data]);
 
     const [validateFn, setValidateFn] = React.useState<ValidateFn>();
 
@@ -58,7 +91,7 @@ const DataValues: React.FC<DataValuesProps> = ({ type }) => {
 
             {loading && <LinearProgress />}
 
-            {data && (
+            {data && cfState.data?.customFormId && (
                 <DataEntry
                     project={data.project}
                     dataSetType={type}
@@ -69,7 +102,7 @@ const DataValues: React.FC<DataValuesProps> = ({ type }) => {
                     goBack={goBack}
                 />
             )}
-            {error && <p>{error}</p>}
+            {(error || cfState.error) && <p>{error || cfState.error}</p>}
         </React.Fragment>
     );
 };

--- a/src/pages/unique-periods/UniquePeriodsForm.tsx
+++ b/src/pages/unique-periods/UniquePeriodsForm.tsx
@@ -10,27 +10,13 @@ import {
 import i18n from "../../locales";
 import { Maybe } from "../../types/utils";
 import { getErrors } from "../../domain/entities/generic/Errors";
+import { months } from "../../utils/date";
 
 export type UniquePeriodsFormProps = {
     existingPeriod?: UniqueBeneficiariesPeriodsAttrs;
     onClose: () => void;
     onSubmit: (uniquePeriods: UniqueBeneficiariesPeriod) => void;
 };
-
-export const months = [
-    { value: "1", text: i18n.t("January") },
-    { value: "2", text: i18n.t("February") },
-    { value: "3", text: i18n.t("March") },
-    { value: "4", text: i18n.t("April") },
-    { value: "5", text: i18n.t("May") },
-    { value: "6", text: i18n.t("June") },
-    { value: "7", text: i18n.t("July") },
-    { value: "8", text: i18n.t("August") },
-    { value: "9", text: i18n.t("September") },
-    { value: "10", text: i18n.t("October") },
-    { value: "11", text: i18n.t("November") },
-    { value: "12", text: i18n.t("December") },
-];
 
 function getValueByAttribute(
     value: string,

--- a/src/types/d2-api.ts
+++ b/src/types/d2-api.ts
@@ -1,9 +1,8 @@
-import { D2Api, D2ModelSchemas, MetadataPayloadBase } from "@eyeseetea/d2-api/2.36";
-import MockAdapter from "axios-mock-adapter/types";
+import { D2Api, D2ModelSchemas, MetadataPayloadBase } from "@eyeseetea/d2-api/2.42";
 
-export * from "@eyeseetea/d2-api/2.36";
+export * from "@eyeseetea/d2-api/2.42";
 
-export function getMockApi(): { api: D2Api; mock: MockAdapter } {
+export function getMockApi() {
     const api = new D2Api({ backend: "xhr" });
     const mock = api.getMockAdapter();
     return { api, mock };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,5 @@
 import moment, { Moment } from "moment";
-import { months } from "../pages/unique-periods/UniquePeriodsForm";
+import i18n from "../locales";
 
 export function toISOString(date: Moment) {
     return date.format("YYYY-MM-DDTHH:mm:ss");
@@ -58,3 +58,18 @@ export function buildMonthYearFormatDate(dateIsoString: string): string {
 export function getMonthNameFromNumber(monthNumber: string | number): string {
     return months.find(month => month.value === monthNumber.toString())?.text || "";
 }
+
+export const months = [
+    { value: "1", text: i18n.t("January") },
+    { value: "2", text: i18n.t("February") },
+    { value: "3", text: i18n.t("March") },
+    { value: "4", text: i18n.t("April") },
+    { value: "5", text: i18n.t("May") },
+    { value: "6", text: i18n.t("June") },
+    { value: "7", text: i18n.t("July") },
+    { value: "8", text: i18n.t("August") },
+    { value: "9", text: i18n.t("September") },
+    { value: "10", text: i18n.t("October") },
+    { value: "11", text: i18n.t("November") },
+    { value: "12", text: i18n.t("December") },
+];

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -1,16 +1,17 @@
 import fs from "fs";
 import tmp from "tmp";
 import _ from "lodash";
-import MockAdapter from "axios-mock-adapter";
-import { Method } from "axios";
+import { getMockApi } from "../types/d2-api";
 
-interface MockAdapterWithHandlers extends MockAdapter {
-    handlers: Record<Method, Handler[]>;
-}
+type MockAdapter = ReturnType<typeof getMockApi>["mock"];
 
 type Url = string;
 type Data = object;
 type Handler = [Url, Data];
+
+interface MockAdapterWithHandlers extends MockAdapter {
+    handlers: Record<string, Handler[]>;
+}
 
 export function logUnknownRequest(mockAdapter: MockAdapter) {
     const mock = mockAdapter as MockAdapterWithHandlers;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,7 +1156,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.1":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.1":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -2890,7 +2890,7 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-i18n@1.1.0", "@dhis2/d2-i18n@^1.0.5":
+"@dhis2/d2-i18n@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.0.tgz#ec777c5091f747e4c5aa4f9801c62ba4d1ef3d16"
   integrity sha512-x3u58goDQsMfBzy50koxNrJjofJTtjRZOfz6f6Py/wMMJfp/T6vZjWMQgcfWH0JrV6d04K1RTt6bI05wqsVQvg==
@@ -3414,36 +3414,20 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.16.0-beta.13":
-  version "1.16.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.16.0-beta.13.tgz#1b46c30c18f5f54339c7e801af18ad941ea028e7"
-  integrity sha512-HtQMSDgIKOaMuS1qqBV6BN5uy6AIVbsyqLsrrF3RrWPUcxZmsZyKqM955F1IYbOROLjEgxu5zJnI2B7n4YDKpA==
+"@eyeseetea/d2-api@1.21.0-beta.5":
+  version "1.21.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.21.0-beta.5.tgz#c6e9590b56d9cf0184fc2c450c483e40a075734a"
+  integrity sha512-fbtpm/fban4/9x5Gjuz0OwuiFSQFKBqCHvSzvy06r8AzoMAieVup8vsQ8+ZwJ1WDtDs40gWvf6b5dhU6+x7XAA==
   dependencies:
-    "@babel/runtime" "^7.5.4"
-    "@dhis2/d2-i18n" "^1.0.5"
-    "@types/prettier" "^1.18.3"
-    "@types/qs" "^6.5.3"
     abort-controller "3.0.0"
-    argparse "^2.0.1"
-    axios "0.19.2"
-    axios-debug-log "^0.6.2"
-    axios-mock-adapter "1.18.2"
+    axios "1.6.4"
+    axios-mock-adapter "1.22.0"
     btoa "^1.2.1"
-    cronstrue "^1.81.0"
-    cryptr "^4.0.2"
-    d2 "^31.8.1"
-    dotenv "^8.0.0"
-    express "^4.17.1"
+    cross-fetch "^4.0.0"
     form-data "^4.0.0"
     iconv-lite "0.6.2"
-    isomorphic-fetch "3.0.0"
-    lodash "^4.17.15"
-    log4js "^4.5.1"
-    node-schedule "^1.3.2"
-    qs "^6.9.0"
-    react "^16.12.0"
-    side-channel "^1.0.4"
-    yargs "^14.0.0"
+    lodash "4.17.21"
+    qs "6.9.7"
 
 "@eyeseetea/d2-ui-components@2.7.0":
   version "2.7.0"
@@ -4304,11 +4288,6 @@
   resolved "https://registry.yarnpkg.com/@types/cryptr/-/cryptr-4.0.1.tgz#d4128be91d1064a2678e695a318b217912881083"
   integrity sha512-Nn8fvr+8XYWK5h422lj4xQACfOg6vdhKI+Rh9ERa5Mg0cZvPL9Vn3845vSY07dNZnEs5cqkSNVMdhmf70lAYkA==
 
-"@types/debug@^4.0.0":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
-  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
-
 "@types/eslint@^7.2.6":
   version "7.2.7"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.7.tgz#f7ef1cf0dceab0ae6f9a976a0a9af14ab1baca26"
@@ -4444,11 +4423,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prettier@^1.18.3":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
-  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
-
 "@types/prettier@^2.0.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
@@ -4463,11 +4437,6 @@
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
-
-"@types/qs@^6.5.3":
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
-  integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
 "@types/react-dom@17.0.0":
   version "17.0.0"
@@ -5355,11 +5324,6 @@ argparse@^1.0.10, argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
 aria-query@5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
@@ -5642,14 +5606,6 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
   integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
 
-axios-debug-log@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/axios-debug-log/-/axios-debug-log-0.6.2.tgz#c7761ced8f1990e6d48c556b517af8e00edcef31"
-  integrity sha512-aavexsFWw+T09e9JkbsNe/zLjdG4r2vwhnKUtCNC/0wpogI/i+bQWJ0jJIuXof734dQ43uiOiFPgbRu8EVa64Q==
-  dependencies:
-    "@types/debug" "^4.0.0"
-    debug "^4.0.0"
-
 axios-mock-adapter@*:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
@@ -5666,6 +5622,14 @@ axios-mock-adapter@1.18.2:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
 
+axios-mock-adapter@1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz#0f3e6be0fc9b55baab06f2d49c0b71157e7c053d"
+  integrity sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
+
 axios-retry@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.9.tgz#6c30fc9aeb4519aebaec758b90ef56fa03fe72e8"
@@ -5673,19 +5637,21 @@ axios-retry@^3.1.9:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@0.21.1, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
+
+axios@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.4.tgz#184ee1f63d412caffcf30d2c50982253c3ee86e0"
+  integrity sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@^0.27.2:
   version "0.27.2"
@@ -7306,19 +7272,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cron-parser@^2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.18.0.tgz#de1bb0ad528c815548371993f81a54e5a089edcf"
-  integrity sha512-s4odpheTyydAbTBQepsqd2rNWGa2iV3cyo8g7zbI2QQYGLVsfbhmwukayS1XHppe02Oy1fg7mg6xoaraVJeEcg==
-  dependencies:
-    is-nan "^1.3.0"
-    moment-timezone "^0.5.31"
-
-cronstrue@^1.81.0:
-  version "1.110.0"
-  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-1.110.0.tgz#cffbef09855141e518341ed5a4b575a5a4811638"
-  integrity sha512-+ABuGZl/nqf/0TemAsPlMSGaB9xEobWhctfRGEqEvH3g6pB/2FGbsUHQPSL8Wt1W3nmOHe1w8GWjacN5k8d3hg==
-
 cross-domain-safe-weakmap@^1, cross-domain-safe-weakmap@^1.0.1:
   version "1.0.29"
   resolved "https://registry.yarnpkg.com/cross-domain-safe-weakmap/-/cross-domain-safe-weakmap-1.0.29.tgz#0847975c27d9e1cc840f24c1745311958df98022"
@@ -7332,6 +7285,13 @@ cross-domain-utils@^2, cross-domain-utils@^2.0.0:
   integrity sha512-zZfi3+2EIR9l4chrEiXI2xFleyacsJf8YMLR1eJ0Veb5FTMXeJ3DpxDjZkto2FhL/g717WSELqbptNSo85UJDw==
   dependencies:
     zalgo-promise "^1.0.11"
+
+cross-fetch@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.1.0.tgz#8f69355007ee182e47fa692ecbaa37a52e43c3d2"
+  integrity sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==
+  dependencies:
+    node-fetch "^2.7.0"
 
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
@@ -7374,11 +7334,6 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
-
-cryptr@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cryptr/-/cryptr-4.0.2.tgz#8a93b5ca7667d1a6131e396bab23a134ff1f5dc6"
-  integrity sha512-gLTcYjmLGe0Kk1yyacvjNKvSdkWBNNgG2tDnbRQP7yE559x/RJLo/I3WAmwCXNXf/fzMHCNp9vDv3PCopZDpXw==
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -7735,13 +7690,6 @@ d2@31.9.0:
   dependencies:
     isomorphic-fetch "^2.2.1"
 
-d2@^31.8.1:
-  version "31.9.1"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-31.9.1.tgz#5b0b8a520dd04a01593698e63156779cbf7f5f88"
-  integrity sha512-dnaDo4reXNt0ySQ6RBUo3EbnixTPs8TrTObYG4HA4ghXF6Xvvru9whUtiR1cRsqD/qlKXxEaUe5CFLw6l+SvyQ==
-  dependencies:
-    isomorphic-fetch "^2.2.1"
-
 d2@~31.1:
   version "31.1.1"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.1.1.tgz#8c551077c27031de8ad2d8df0b575242a3080917"
@@ -7793,11 +7741,6 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-format@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
-  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
-
 dayjs@^1.8.34:
   version "1.11.9"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
@@ -7815,21 +7758,14 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -8208,7 +8144,7 @@ dotenv-expand@5.1.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv@8.2.0, dotenv@^8.0.0:
+dotenv@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
@@ -9455,11 +9391,6 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-
 flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
@@ -9486,13 +9417,6 @@ fluture@^14.0.0:
     sanctuary-show "^2.0.0"
     sanctuary-type-identifiers "^3.0.0"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
@@ -9502,6 +9426,11 @@ follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+follow-redirects@^1.15.4:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 font-awesome@^4.7.0:
   version "4.7.0"
@@ -9598,7 +9527,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^7.0.0, fs-extra@^7.0.1:
+fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -10762,7 +10691,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.3:
+is-buffer@^2.0.3, is-buffer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -10961,14 +10890,6 @@ is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
-
-is-nan@^1.3.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-negated-glob@^1.0.0:
   version "1.0.0"
@@ -11277,14 +11198,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
-  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
-  dependencies:
-    node-fetch "^2.6.1"
-    whatwg-fetch "^3.4.1"
 
 isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
@@ -12520,26 +12433,10 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-log4js@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-4.5.1.tgz#e543625e97d9e6f3e6e7c9fc196dd6ab2cae30b5"
-  integrity sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==
-  dependencies:
-    date-format "^2.0.0"
-    debug "^4.1.1"
-    flatted "^2.0.0"
-    rfdc "^1.1.4"
-    streamroller "^1.0.6"
-
 loglevel@^1.4.0, loglevel@^1.6.1, loglevel@^1.6.8:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
-
-long-timeout@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
-  integrity sha1-lyHXiLR+C8taJMLivuGg2lXatRQ=
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -12963,19 +12860,12 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment-timezone@^0.5.31:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
-  dependencies:
-    moment ">= 2.9.0"
-
 moment@2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
-moment@2.29.1, "moment@>= 2.9.0", moment@^2.22.1, moment@^2.24.0, moment@^2.29.1:
+moment@2.29.1, moment@^2.22.1, moment@^2.24.0, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -13137,10 +13027,12 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -13209,15 +13101,6 @@ node-releases@^1.1.61, node-releases@^1.1.70:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
-
-node-schedule@^1.3.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/node-schedule/-/node-schedule-1.3.3.tgz#f8e01c5fb9597f09ecf9c4c25d6938e5e7a06f48"
-  integrity sha512-uF9Ubn6luOPrcAYKfsXWimcJ1tPFtQ8I85wb4T3NgJQrXazEzojcFZVk46ZlLHby3eEJChgkV/0T689IsXh2Gw==
-  dependencies:
-    cron-parser "^2.18.0"
-    long-timeout "0.1.1"
-    sorted-array-functions "^1.3.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -14818,6 +14701,11 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -14890,12 +14778,10 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.9.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.0.tgz#8b6519121ab291c316a3e4d49cecf6d13d8c7fe5"
-  integrity sha512-yjACOWijC6L/kmPZZAsVBNY2zfHSIbpdpL977quseu56/8BZ2LoF5axK2bGhbzhVKt7V9xgWTtpyLbxwIoER0Q==
-  dependencies:
-    side-channel "^1.0.4"
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
 qs@^6.9.6:
   version "6.10.1"
@@ -15288,15 +15174,6 @@ react@17.0.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-react@^16.12.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -15800,11 +15677,6 @@ rework@1.0.1:
   dependencies:
     convert-source-map "^0.3.3"
     css "^2.0.0"
-
-rfdc@^1.1.4:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
-  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -16369,11 +16241,6 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-sorted-array-functions@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz#8605695563294dffb2c9796d602bd8459f7a0dd5"
-  integrity sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==
-
 sortobject@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.3.0.tgz#bc8ce57014c567bdbf78e89ae6c484e64d51e9dc"
@@ -16630,17 +16497,6 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-streamroller@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-1.0.6.tgz#8167d8496ed9f19f05ee4b158d9611321b8cacd9"
-  integrity sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==
-  dependencies:
-    async "^2.6.2"
-    date-format "^2.0.0"
-    debug "^3.2.6"
-    fs-extra "^7.0.1"
-    lodash "^4.17.14"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -17300,6 +17156,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
@@ -17935,6 +17796,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -18092,6 +17958,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0:
   version "8.4.0"
@@ -18479,14 +18353,6 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -18515,23 +18381,6 @@ yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
-
-yargs@^14.0.0:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
-  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.1"
 
 yargs@^15.4.1:
   version "15.4.1"


### PR DESCRIPTION
## Summary

- Country dashboards were set to **public read+write** (`rw------`), allowing any logged-in user to see and edit all country dashboards regardless of their project assignments.
- Changed `CountryDashboard.getSharing()` to set `public: "--------"` and restrict access to the aggregated users and user groups from all projects within that country — matching the pattern already used by project dashboards via `ProjectSharing`.
- Added **migration task 10** to regenerate all existing country dashboards with the corrected sharing settings.

## Test plan

- [x] All existing tests pass (48/48)
- [x] Test fixture updated to reflect new sharing structure
- [ ] Verify on a DHIS2 instance that country dashboards are no longer visible to users without project assignments in that country
- [ ] Verify that users with project assignments in a country can still see the country dashboard
- [ ] Run migration 10 on a test instance and confirm existing dashboards are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)