### PR TITLE
Add general-purpose script for deleting dangling data values

### DIFF
--- a/src/scripts/delete-dangling-data-values.ts
+++ b/src/scripts/delete-dangling-data-values.ts
@@ -1,0 +1,184 @@
+import _ from "lodash";
+import parse from "parse-typed-args";
+import { D2Api, Id } from "../types/d2-api";
+import { getConfig, Config } from "../models/Config";
+import Project from "../models/Project";
+import ProjectDb, { DataValue, getStringDataValue } from "../models/ProjectDb";
+import ProjectsList from "../models/ProjectsList";
+import { writeDataFilePath, readDataFilePath, assert } from "./common";
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});
+
+const paths = {
+    danglingReport: "dangling-data-values-report",
+    danglingToDelete: "dangling-data-values-to-delete",
+};
+
+async function main() {
+    const parser = parse({
+        opts: {
+            url: {},
+            project: {},
+            generate: { switch: true },
+            post: { switch: true },
+        },
+    });
+    const { opts } = parser(process.argv);
+
+    const usage = [
+        "Usage: delete-dangling-data-values --url=DHIS2URL [--generate | --post] [--project=PROJECT_ID]",
+        "",
+        "Options:",
+        "  --url        DHIS2 instance URL (required)",
+        "  --generate   Detect dangling data values and write report files (dry run)",
+        "  --post       Delete the dangling data values found by a previous --generate run",
+        "  --project    Process only a specific project by ID (optional, processes all if omitted)",
+    ].join("\n");
+
+    const app = opts.url ? await getAppContext(opts.url) : null;
+
+    if (!app) {
+        console.error(usage);
+        process.exit(1);
+    } else if (opts.generate) {
+        await generateReport(app, opts.project);
+    } else if (opts.post) {
+        await postDeletion(app);
+    } else {
+        console.error(usage);
+        process.exit(1);
+    }
+}
+
+interface AppContext {
+    api: D2Api;
+    config: Config;
+}
+
+async function getAppContext(baseUrl: string): Promise<AppContext> {
+    const api = new D2Api({ baseUrl });
+    const config = await getConfig(api);
+    return { api, config };
+}
+
+interface ProjectDanglingResult {
+    projectId: Id;
+    projectName: string;
+    countryName: string;
+    danglingValues: DataValue[];
+}
+
+async function getProjectIds(api: D2Api, config: Config): Promise<Id[]> {
+    const { objects: projectItems } = await new ProjectsList(api, config).get(
+        {},
+        { field: "id", order: "asc" },
+        { page: 1, pageSize: 100000 }
+    );
+
+    return _(projectItems)
+        .orderBy([project => project.parent.displayName, project => project.displayName])
+        .map(project => project.id)
+        .value();
+}
+
+async function generateReport(app: AppContext, projectIdFilter?: string) {
+    const { api, config } = app;
+
+    const projectIds = projectIdFilter ? [projectIdFilter] : await getProjectIds(api, config);
+
+    console.log(`Processing ${projectIds.length} project(s)...`);
+
+    const allResults: ProjectDanglingResult[] = [];
+    let totalDangling = 0;
+
+    for (const [idx, projectId] of projectIds.entries()) {
+        let project: Project;
+        try {
+            project = await Project.get(api, config, projectId);
+        } catch (err) {
+            console.error(
+                `  [${idx + 1}/${projectIds.length}] Error loading project ${projectId}: ${err}`
+            );
+            continue;
+        }
+
+        const projectName = project.name;
+        const countryName = project.parentOrgUnit?.displayName || "Unknown";
+        console.log(
+            `  [${idx + 1}/${projectIds.length}] [${countryName}] ${projectName} (${projectId})`
+        );
+
+        const projectDb = new ProjectDb(project);
+        const danglingValues = await projectDb.getDanglingDataValues();
+
+        if (danglingValues.length > 0) {
+            console.log(`    -> Found ${danglingValues.length} dangling data value(s)`);
+            danglingValues.forEach(dv => console.log(`       ${getStringDataValue(dv)}`));
+
+            allResults.push({ projectId, projectName, countryName, danglingValues });
+            totalDangling += danglingValues.length;
+        }
+    }
+
+    console.log(
+        `\nSummary: ${totalDangling} dangling data value(s) across ${allResults.length} project(s)`
+    );
+
+    if (totalDangling === 0) {
+        console.log("Nothing to delete.");
+        return;
+    }
+
+    // Write human-readable report
+    const report = allResults.map(result => ({
+        project: `[${result.countryName}] ${result.projectName} (${result.projectId})`,
+        count: result.danglingValues.length,
+        dataValues: result.danglingValues.map(getStringDataValue),
+    }));
+    writeDataFilePath(paths.danglingReport, report);
+
+    // Write DHIS2 delete payload
+    const dataValuesToDelete = allResults.flatMap(result =>
+        result.danglingValues.map(dv => ({
+            dataElement: dv.dataElement.id,
+            period: dv.period,
+            orgUnit: result.projectId,
+            categoryOptionCombo: dv.categoryOptionCombo.id,
+            attributeOptionCombo: dv.attributeOptionCombo.id,
+            value: "",
+        }))
+    );
+
+    writeDataFilePath(paths.danglingToDelete, { dataValues: dataValuesToDelete });
+
+    console.log(`\nReview the report, then run with --post to delete.`);
+}
+
+async function postDeletion(app: AppContext) {
+    let metadata: { dataValues: Array<Record<string, string>> };
+    try {
+        metadata = readDataFilePath(paths.danglingToDelete);
+    } catch (err) {
+        console.error(`Cannot read delete payload. Run --generate first.`);
+        process.exit(1);
+    }
+
+    const count = metadata.dataValues.length;
+    if (count === 0) {
+        console.log("No data values to delete.");
+        return;
+    }
+
+    console.log(`Deleting ${count} dangling data value(s)...`);
+
+    const res = await app.api.dataValues
+        .postSet({ importStrategy: "DELETE" }, metadata as any)
+        .getData();
+
+    console.log("Response:", JSON.stringify(res, null, 2));
+    assert(res.status === "SUCCESS", `Delete failed: ${JSON.stringify(res)}`);
+    console.log("Done. Dangling data values deleted successfully.");
+}


### PR DESCRIPTION
## Summary

- Adds a new `delete-dangling-data-values.ts` script that replaces the old `delete-wrong-data-values.ts`, which was hardcoded to a specific DHIS2 instance and COVID-specific category combos.
- Reuses the existing `ProjectDb.getDanglingDataValues()` detection logic, which identifies data values whose `(dataElement, categoryOptionCombo)` pair no longer matches the project's current configuration.
- Works across all projects or a specific one via `--project=ID`.
- Two-step workflow: `--generate` writes a report + delete payload for review, `--post` executes the deletion.

## Usage

```bash
# Step 1: Generate report (dry run)
yarn ts-node src/scripts/delete-dangling-data-values.ts --url=https://dhis2-instance.org --generate

# Or for a specific project:
yarn ts-node src/scripts/delete-dangling-data-values.ts --url=https://dhis2-instance.org --generate --project=PROJECT_ID

# Step 2: Review the generated files in src/scripts/data/
#   - dangling-data-values-report.json (human-readable)
#   - dangling-data-values-to-delete.json (DHIS2 delete payload)

# Step 3: Delete after review
yarn ts-node src/scripts/delete-dangling-data-values.ts --url=https://dhis2-instance.org --post
```

## Context

A client reported that after removing and re-adding an indicator from a project, "dangling" data values remained in the DHIS2 database. These orphaned values were still visible in their Tableau extracts from the DHIS2 PostgreSQL. The app already detects and notifies about dangling data (via `ProjectNotification`), but had no general-purpose tool to clean them up.

## Test plan

- [x] Type-checks cleanly
- [x] All existing tests pass (47/47)
- [ ] Run `--generate` against a test DHIS2 instance and verify the report is accurate
- [ ] Run `--post` and verify dangling values are removed from DHIS2

🤖 Generated with [Claude Code](https://claude.com/claude-code)